### PR TITLE
Better configuration and discrimated unions

### DIFF
--- a/src/dataclassio/config.py
+++ b/src/dataclassio/config.py
@@ -1,0 +1,63 @@
+import typing_extensions as tp
+from collections import ChainMap
+
+from .types import EFS
+
+
+__all__ = ("DioOptions", "NoValue", "get_composite_options")
+
+
+class _NoValue:
+    def __repr__(self) -> str:
+        return "<NoValueProvided>"
+
+
+NoValue: tp.Final = _NoValue()
+
+
+class DioOptions(tp.TypedDict, total=False):
+    discriminator: str | _NoValue
+    """Key to use for discriminating unions.
+
+    E.g., if each member of the Union has a "type: str" field, then if `discriminator: "type"`, DIO will parse the
+    `type` member of each object to decide what call to use.
+    """
+    extra_field_strategy: EFS
+    """Method for handling the presence of extra fields in an object."""
+
+
+DIO_DEFAULT_OPTIONS = DioOptions(discriminator=NoValue, extra_field_strategy=EFS.IGNORE)
+
+
+def get_composite_options(
+    field_options: DioOptions | None = None,
+    call_options: DioOptions | None = None,
+    type_options: DioOptions | None = None,
+) -> DioOptions:
+    """Provide a config object that merges DioOptions at various precedence levels.
+
+    The options are merged with the following predence level:
+
+        # Top-Priority
+        1. Field-level options (does not cascade)
+        2. Call-level options (cascades)
+        3. Type-level options (does not cascade)
+        4. Global default options
+        # Lowest-Priority
+
+    Notes:
+        The given priorities are based on conventions from other serialization libraries, like `mashumaro` or
+        `pydantic`.
+
+    Returns:
+        A MutableMapping with the DioOptions
+    """
+    return tp.cast(
+        DioOptions,
+        ChainMap(
+            field_options or {},
+            call_options or {},
+            type_options or {},
+            DIO_DEFAULT_OPTIONS,
+        ),
+    )

--- a/src/dataclassio/config.py
+++ b/src/dataclassio/config.py
@@ -1,15 +1,26 @@
-import typing_extensions as tp
 from collections import ChainMap
+
+import typing_extensions as tp
 
 from .types import EFS
 
+__all__ = (
+    "DioOptions",
+    "FieldOpts",
+    "get_composite_options",
+    "get_options_cache_key",
+    "NoValue",
+)
 
-__all__ = ("DioOptions", "NoValue", "get_composite_options")
+T = tp.TypeVar("T", bound=type)
 
 
 class _NoValue:
     def __repr__(self) -> str:
         return "<NoValueProvided>"
+
+    def __str__(self) -> str:
+        return "NoValueProvided"
 
 
 NoValue: tp.Final = _NoValue()
@@ -17,23 +28,31 @@ NoValue: tp.Final = _NoValue()
 
 class DioOptions(tp.TypedDict, total=False):
     discriminator: str | _NoValue
-    """Key to use for discriminating unions.
-
-    E.g., if each member of the Union has a "type: str" field, then if `discriminator: "type"`, DIO will parse the
-    `type` member of each object to decide what call to use.
-    """
     extra_field_strategy: EFS
-    """Method for handling the presence of extra fields in an object."""
+    skip_defaults: bool
 
 
-DIO_DEFAULT_OPTIONS = DioOptions(discriminator=NoValue, extra_field_strategy=EFS.IGNORE)
+class _TotalDioOptions(DioOptions):
+    discriminator: str | _NoValue
+    extra_field_strategy: EFS
+    skip_defaults: bool
+
+
+def FieldOpts(**kw: tp.Unpack[DioOptions]):
+    """Make DioOptions for `field(metadata=...)`."""
+    return {"dio": DioOptions(**kw)}
+
+
+DIO_DEFAULT_OPTIONS = _TotalDioOptions(
+    discriminator=NoValue, extra_field_strategy=EFS.IGNORE, skip_defaults=False
+)
 
 
 def get_composite_options(
-    field_options: DioOptions | None = None,
-    call_options: DioOptions | None = None,
-    type_options: DioOptions | None = None,
-) -> DioOptions:
+    field_options: _TotalDioOptions | DioOptions | None = None,
+    call_options: _TotalDioOptions | DioOptions | None = None,
+    type_options: _TotalDioOptions | DioOptions | None = None,
+) -> _TotalDioOptions:
     """Provide a config object that merges DioOptions at various precedence levels.
 
     The options are merged with the following predence level:
@@ -53,7 +72,7 @@ def get_composite_options(
         A MutableMapping with the DioOptions
     """
     return tp.cast(
-        DioOptions,
+        _TotalDioOptions,
         ChainMap(
             field_options or {},
             call_options or {},
@@ -61,3 +80,38 @@ def get_composite_options(
             DIO_DEFAULT_OPTIONS,
         ),
     )
+
+
+_FROM_KEYS = frozenset(("discriminator", "extra_field_strategy"))
+_TO_KEYS = frozenset(("discriminator", "skip_defaults"))
+
+
+def _build_string(opts: DioOptions):
+    str_data = []
+
+    if "discriminator" in opts and opts["discriminator"] != DIO_DEFAULT_OPTIONS["discriminator"]:
+        str_data.append(f"discriminator_{opts['discriminator']}")
+
+    if (
+        "extra_field_strategy" in opts
+        and opts["extra_field_strategy"] != DIO_DEFAULT_OPTIONS["extra_field_strategy"]
+    ):
+        str_data.append(f"efs_{opts['extra_field_strategy'].value}")
+
+    if "skip_defaults" in opts and opts["skip_defaults"] != DIO_DEFAULT_OPTIONS["skip_defaults"]:
+        str_data.append(f"skip_defaults_{opts['skip_defaults']!s}")
+
+    postfix = "__".join(str_data)
+    if postfix:
+        postfix = f"_{postfix}"
+    return postfix
+
+
+def get_options_cache_key(
+    options: DioOptions | _TotalDioOptions, direction: tp.Literal["from_dict", "to_dict"]
+) -> tuple[tp.Hashable, str]:
+    relevant_keys = _FROM_KEYS if direction == "from_dict" else _TO_KEYS
+    filtered_data = tp.cast(DioOptions, {k: v for k, v in options.items() if k in relevant_keys})
+
+    data = tuple(sorted(filtered_data.items()))
+    return data, _build_string(filtered_data)

--- a/src/dataclassio/core/expression_builder.py
+++ b/src/dataclassio/core/expression_builder.py
@@ -17,7 +17,7 @@ class SerializerData(tp.NamedTuple):
     registry: tp.MutableMapping
     namespace: tp.MutableMapping
     maker_func: tp.Callable[[DataclassInstance], tp.Callable]
-    cache_args: tuple
+    cache_key: tuple[tp.Hashable, str]
 
 
 def build_expr(
@@ -86,12 +86,13 @@ def build_expr(
 
     # 2. Handle atoms (note that we don't recurse into `build_expr`)
     if dcs.is_dataclass(t):
-        cache_key = (t, *serializer_data.cache_args)
+        cache_data, func_postfix = serializer_data.cache_key
+        cache_key = (t, cache_data)
         if cache_key not in serializer_data.registry:
             serializer_data.registry[cache_key] = None  # Refuse to recurse.
             serializer_data.registry[cache_key] = serializer_data.maker_func(t)
 
-        fname = make_variable_name(f"{func_prefix}_{t.__name__}")
+        fname = make_variable_name(f"{func_prefix}_{t.__name__}{func_postfix}")
         serializer_data.namespace[fname] = serializer_data.registry[cache_key]
         return f"{fname}({expr_str})"
 

--- a/src/dataclassio/core/expression_builder.py
+++ b/src/dataclassio/core/expression_builder.py
@@ -5,8 +5,9 @@ from datetime import datetime
 
 import typing_extensions as tp
 
+from ..config import NoValue, _TotalDioOptions
 from ..types import DataclassInstance
-from .common import make_variable_name, strip_optional
+from .common import get_fields, make_variable_name, strip_optional
 
 __all__ = ("SerializerData", "build_expr", "get_field_expression")
 
@@ -18,6 +19,7 @@ class SerializerData(tp.NamedTuple):
     namespace: tp.MutableMapping
     maker_func: tp.Callable[[DataclassInstance], tp.Callable]
     cache_key: tuple[tp.Hashable, str]
+    options: _TotalDioOptions
 
 
 def build_expr(
@@ -84,6 +86,69 @@ def build_expr(
             return expr_str
         return f"{{{k_expr}: {v_expr} for k, v in {expr_str}.items()}}"
 
+    if (origin is tp.Union or origin is types.UnionType) and any(
+        dcs.is_dataclass(a) for a in args
+    ):
+        if not all(dcs.is_dataclass(a) for a in args):
+            msg = (
+                f"type={t}, generated via {expr_str=} is not supported."
+                " Union types with any dataclass options must be _all_ dataclasses."
+            )
+            raise RuntimeError(msg)
+        # check the field options.
+        discriminator = serializer_data.options["discriminator"]
+        if discriminator is NoValue:
+            msg = (
+                f"type={t}, generated via {expr_str=} is not supported."
+                " A discriminator field was not provided."
+            )
+        assert isinstance(discriminator, str)
+
+        # base case
+        if func_prefix == "deserialize":
+            # from_dict
+            inner_expr = f"{expr_str}[{discriminator!r}]"
+        else:
+            # to_dict
+            inner_expr = f"{expr_str}.{discriminator!s}"
+
+        # build list of types:
+        maker_map_data: dict[str, tp.Any] = {}
+        for cls_option in args:
+            fields = [f for f in get_fields(cls_option) if f.name == discriminator]
+            if not fields:
+                msg = (
+                    f"type={t}, generated via {expr_str=} is not supported."
+                    f"Union option {cls_option} does not have a field with the name {discriminator}."
+                )
+                raise RuntimeError(msg)
+            # get the type.
+            f_type = fields[0].type
+            discrim_origin = tp.get_origin(f_type)
+            discrim_args = tp.get_args(f_type)
+            if discrim_origin is not tp.Literal or not all(
+                isinstance(x, str) for x in discrim_args
+            ):
+                msg = (
+                    f"type={t}, generated via {expr_str=} is not supported."
+                    f"Union option {cls_option} has a field with name {discriminator}, but it is not a Literal with string arguments."
+                )
+                raise RuntimeError(msg)
+            maker_func = serializer_data.maker_func(cls_option)
+            for arg_name in discrim_args:
+                if arg_name in maker_map_data:
+                    msg = (
+                        f"type={t}, generated via {expr_str=} is not supported."
+                        f"The union options have duplicate values for {discriminator}."
+                    )
+                    raise RuntimeError(msg)
+                maker_map_data[arg_name] = maker_func
+
+        fname = make_variable_name("_DISAMBIGUATOR", ns=serializer_data.namespace)
+        serializer_data.namespace[fname] = maker_map_data
+        # build the final expression:
+        return f"{fname}[{inner_expr}]({expr_str})"
+
     # 2. Handle atoms (note that we don't recurse into `build_expr`)
     if dcs.is_dataclass(t):
         cache_data, func_postfix = serializer_data.cache_key
@@ -120,12 +185,6 @@ def build_expr(
         return f"{fname}({expr_str})"
 
     # 3. Fallbacks
-    if (origin is tp.Union or origin is types.UnionType) and (
-        any(dcs.is_dataclass(a) for a in args)
-    ):
-        msg = f"type: {t} with {origin=} and {args=}, generated via {expr_str=} is not supported"
-        raise RuntimeError(msg)
-
     return expr_str
 
 

--- a/src/dataclassio/functional/from_dict.py
+++ b/src/dataclassio/functional/from_dict.py
@@ -80,6 +80,7 @@ def make_from_dict_source_code(
                 namespace=ns,
                 maker_func=lambda t: make_from_dict(t, options=field_options),
                 cache_key=get_options_cache_key(field_options, "from_dict"),
+                options=field_options,
             ),
             direction="from_dict",
         )

--- a/src/dataclassio/functional/from_dict.py
+++ b/src/dataclassio/functional/from_dict.py
@@ -3,6 +3,12 @@ import inspect
 
 import typing_extensions as tp
 
+from ..config import (
+    DioOptions,
+    _TotalDioOptions,
+    get_composite_options,
+    get_options_cache_key,
+)
 from ..core import (
     SerializerData,
     TextLines,
@@ -20,7 +26,7 @@ __all__ = (
     "make_from_dict",
 )
 
-_KNOWN_DESERIALIZERS: dict[tuple[type, EFS], tp.Callable[[tp.Mapping], tp.Any]] = {}
+_KNOWN_DESERIALIZERS: dict[tuple[type, tp.Any], tp.Callable[[tp.Mapping], tp.Any]] = {}
 _EXTRA_FIELD_ATTR_NAME = "_extra_fields"
 _SPACER = "  "
 
@@ -43,21 +49,28 @@ class FieldSpec(tp.NamedTuple):
 def make_from_dict_source_code(
     cls: type[DataclassInstance],
     funcname: str = "",
-    extra_field_strategy=EFS.IGNORE,
+    options: DioOptions | None = None,  # call_options
 ) -> tuple[TextLines, dict[str, tp.Any]]:
     """Generate the source code and necessary namespace for a from_dict deserialization method."""
     funcname = funcname or f"deserialize_{cls.__name__}"
     cls_factory_name = make_variable_name("cls")
     ns: dict[str, tp.Any] = {cls_factory_name: cls}
+    current_variable_names: set = {cls_factory_name, "dikt", "_exc"}
+
+    call_options = get_composite_options(call_options=options)
 
     fields = get_fields(cls, include_all=True)
     field_data: dict[str, FieldSpec] = {}
 
-    current_variable_names: set = {cls_factory_name, "dikt", "_exc"}
     for f in fields:
         if not f.init:
             # init=False field. Don't try to read it in.
             continue
+
+        # extract and integrate field-options
+        field_options = get_composite_options(
+            field_options=f.metadata.get("dio"), call_options=options
+        )
 
         # Get the expression for parsing this field.
         field_expr = get_field_expression(
@@ -65,8 +78,8 @@ def make_from_dict_source_code(
             serializer_data=SerializerData(
                 registry=_KNOWN_DESERIALIZERS,
                 namespace=ns,
-                maker_func=lambda t: make_from_dict(t, extra_field_strategy=extra_field_strategy),
-                cache_args=(extra_field_strategy,),
+                maker_func=lambda t: make_from_dict(t, options=field_options),
+                cache_key=get_options_cache_key(field_options, "from_dict"),
             ),
             direction="from_dict",
         )
@@ -120,7 +133,10 @@ def make_from_dict_source_code(
         data_str = ", ".join(init_parts)
 
         extras = _handle_extra_fields(
-            fields, extra_field_strategy, ns=ns, attribute_name=_EXTRA_FIELD_ATTR_NAME
+            fields,
+            call_options["extra_field_strategy"],
+            ns=ns,
+            attribute_name=_EXTRA_FIELD_ATTR_NAME,
         )
         if extras:
             lines.append(f"inst = {cls_factory_name}({data_str})")
@@ -134,18 +150,24 @@ def make_from_dict_source_code(
 
 def make_from_dict(
     cls: type[DataclassInstance],
-    extra_field_strategy: EFS = EFS.IGNORE,
+    *,
     include_src_in_docstring: bool = False,
+    options: _TotalDioOptions | DioOptions | None = None,
+    **kw: tp.Unpack[DioOptions],
 ):
     """Make a from_dict deserialization method for the given dataclass."""
-    if (f := _KNOWN_DESERIALIZERS.get((cls, extra_field_strategy), None)) is not None:
+    options = options or {}
+    options.update(kw)
+
+    opts = get_composite_options(call_options=options)
+    key, str_key = get_options_cache_key(opts, "from_dict")
+
+    if (f := _KNOWN_DESERIALIZERS.get((cls, key), None)) is not None:
         return f
 
-    func_name = f"deserialize_{cls.__name__}"
-    file_name = f"dataclassio/generated/{func_name}_efs_{extra_field_strategy.value}.py"
-    src, ns = make_from_dict_source_code(
-        cls, funcname=func_name, extra_field_strategy=extra_field_strategy
-    )
+    func_name = f"deserialize_{cls.__name__}{str_key}"
+    file_name = f"dataclassio/generated/{func_name}{str_key}.py"
+    src, ns = make_from_dict_source_code(cls, funcname=func_name, options=options)
 
     code_obj = cache_source_code(src, file_name)
     exec(code_obj, ns)

--- a/src/dataclassio/functional/to_dict.py
+++ b/src/dataclassio/functional/to_dict.py
@@ -49,6 +49,7 @@ def make_to_dict_source_code(
                 namespace=ns,
                 maker_func=lambda t: make_to_dict(t, options=field_options),
                 cache_key=get_options_cache_key(field_options, "to_dict"),
+                options=field_options,
             ),
         )
 

--- a/src/dataclassio/functional/to_dict.py
+++ b/src/dataclassio/functional/to_dict.py
@@ -1,5 +1,6 @@
 import typing_extensions as tp
 
+from ..config import DioOptions, _TotalDioOptions, get_composite_options, get_options_cache_key
 from ..core import (
     SerializerData,
     TextLines,
@@ -12,17 +13,19 @@ from ..types import DataclassInstance
 from ._shared import cache_source_code
 from .from_dict import _EXTRA_FIELD_ATTR_NAME
 
-_KNOWN_SERIALIZERS: dict[tuple[type, bool], tp.Callable[[DataclassInstance], dict]] = {}
+_KNOWN_SERIALIZERS: dict[tuple[type, tp.Hashable], tp.Callable[[DataclassInstance], dict]] = {}
 _SPACER = "  "
 
 
 def make_to_dict_source_code(
     cls: type[DataclassInstance],
     funcname: str = "",
-    skip_defaults: bool = False,
+    options: _TotalDioOptions | DioOptions | None = None,  # call_options
 ) -> tuple[TextLines, dict[str, tp.Any]]:
     funcname = funcname or f"serialize_{cls.__name__}"
     ns: dict[str, tp.Any] = {}
+
+    call_options = get_composite_options(call_options=options)
 
     # Start building up the output.
     # We are going to serialize objects. We also need to check if they
@@ -33,14 +36,19 @@ def make_to_dict_source_code(
     literal_lines = TextLines(spacer=_SPACER)
     for f in get_fields(cls):
         # Form the expression itself that gets the value.
+
+        field_options = get_composite_options(
+            field_options=f.metadata.get("dio"), call_options=options
+        )
+
         field_expr = get_field_expression(
             f,
             direction="to_dict",
             serializer_data=SerializerData(
                 registry=_KNOWN_SERIALIZERS,
                 namespace=ns,
-                maker_func=lambda t: make_to_dict(t, skip_defaults=skip_defaults),
-                cache_args=(skip_defaults,),
+                maker_func=lambda t: make_to_dict(t, options=field_options),
+                cache_key=get_options_cache_key(field_options, "to_dict"),
             ),
         )
 
@@ -51,7 +59,7 @@ def make_to_dict_source_code(
 
         # We need an explicit check for `has_default` since `get_default` cannot distinguish between
         # "no default" and "default=None".
-        if skip_defaults and field_has_default(f):
+        if call_options["skip_defaults"] and field_has_default(f):
             # Add a hardcoded gate that checks if we have a default value. If so, don't
             #  add anything to the dict.
             default_expression = parse_default_expression(f, ns, precompute_factory=False)
@@ -92,21 +100,30 @@ def make_to_dict_source_code(
 
 def make_to_dict(
     cls: type[DataclassInstance],
-    skip_defaults: bool = False,
+    *,
     include_src_in_docstring: bool = True,
+    options: _TotalDioOptions | DioOptions | None = None,
+    **kw: tp.Unpack[DioOptions],
 ):
-    if (f := _KNOWN_SERIALIZERS.get((cls, skip_defaults), None)) is not None:
+    """Make a to_dict serialization method for the given dataclass."""
+    options = options or {}
+    options.update(kw)
+
+    opts = get_composite_options(call_options=options)
+    key, str_key = get_options_cache_key(opts, "to_dict")
+
+    if (f := _KNOWN_SERIALIZERS.get((cls, key), None)) is not None:
         return f
 
-    func_name = f"serialize_{cls.__name__}"
-
-    file_name = f"dataclassio/generated/{func_name}_skip_defaults_{skip_defaults!s}.py"
-    src, ns = make_to_dict_source_code(cls=cls, funcname=func_name, skip_defaults=skip_defaults)
+    func_name = f"serialize_{cls.__name__}{str_key}"
+    file_name = f"dataclassio/generated/{func_name}{str_key}.py"
+    src, ns = make_to_dict_source_code(cls=cls, funcname=func_name, options=options)
 
     code_obj = cache_source_code(src, file_name)
-
     exec(code_obj, ns)
+
     func = ns[func_name]
     if include_src_in_docstring:
         func.__doc__ += f"\n\n{src[2:]!s}\n"
+
     return func

--- a/src/dataclassio/io_mixin.py
+++ b/src/dataclassio/io_mixin.py
@@ -5,9 +5,10 @@ from dataclasses import dataclass
 
 import typing_extensions as tp
 
+from .config import DioOptions
 from .functional import make_from_dict, make_to_dict
 from .functional.from_dict import _EXTRA_FIELD_ATTR_NAME
-from .types import EFS, PathOrHandle
+from .types import PathOrHandle
 
 
 @contextlib.contextmanager
@@ -36,8 +37,10 @@ class IOMixin:
     def from_json_file(
         cls: type[tp.Self],
         fname_or_handle: PathOrHandle,
-        extra_field_strategy: EFS = EFS.IGNORE,
+        *,
         load_kw: tp.Mapping[str, tp.Any] | None = None,
+        options: DioOptions | None = None,
+        **kw: tp.Unpack[DioOptions],
     ):
         """Initialize this class from a JSON file.
 
@@ -51,56 +54,54 @@ class IOMixin:
         with _fname_or_fpointer(fname_or_handle, mode="rb") as fp:
             obj = json.load(fp, **load_kw)
 
-        return cls.from_dict(obj, extra_field_strategy=extra_field_strategy)
+        return cls.from_dict(obj, options=options, **kw)
 
     @classmethod
     def from_dict(
-        cls: type[tp.Self], dikt: tp.Mapping[str, tp.Any], extra_field_strategy: EFS = EFS.IGNORE
+        cls: type[tp.Self],
+        dikt: tp.Mapping[str, tp.Any],
+        *,
+        options: DioOptions | None = None,
+        **kw: tp.Unpack[DioOptions],
     ) -> tp.Self:
         """Initialize this class from a dictionary."""
 
-        # Cache based on desired extra field strategy
-        meth_name = f"_dict_deserializer_method_ef_{extra_field_strategy.name}"
-        method = getattr(cls, meth_name, None)
-        if method is None:
-            method = make_from_dict(cls, extra_field_strategy=extra_field_strategy)
-            setattr(cls, meth_name, method)
+        # Rely on internal cache.
+        method = make_from_dict(cls, options=options, **kw)
         return method(dikt)
 
-    def to_dict(self, skip_defaults: bool = False) -> dict[str, tp.Any]:
+    def to_dict(
+        self,
+        *,
+        options: DioOptions | None = None,
+        **kw: tp.Unpack[DioOptions],
+    ) -> dict[str, tp.Any]:
         """Serialize this class to a dictionary.
-
-        Args:
-            skip_defaults: Flag to skip serialization of default-valued entries in this instance.
 
         Returns:
             A dictionary representation of this class.
         """
-
-        # Cache based on if we are skipping defaults.
+        # Rely on internal cache.
         cls = self.__class__
-        meth_name = f"_dict_serializer_method_skip_{skip_defaults}"
-        method = getattr(cls, meth_name, None)
-        if method is None:
-            method = make_to_dict(cls, skip_defaults=skip_defaults)
-            setattr(cls, meth_name, method)
+        method = make_to_dict(cls, options=options, **kw)
         return method(self)
 
     def to_json_file(
         self,
         fname_or_handle: PathOrHandle,
-        skip_defaults: bool = False,
+        *,
         dump_kw: tp.Mapping[str, tp.Any] | None = None,
+        options: DioOptions | None = None,
+        **kw: tp.Unpack[DioOptions],
     ):
         """Serialize this instance to a JSON file.
 
         Args:
             fname_or_handle: Path to a file or a filepointer to write to. If a pointer is provided,
                 it must support text-based writing.
-            skip_defaults: Flag to skip serialization of default-valued entries in this instance.
             dump_kw: Kwargs to forward to `json.dump(...)`, such as `cls`.
         """
-        obj = self.to_dict(skip_defaults=skip_defaults)
+        obj = self.to_dict(options=options, **kw)
 
         dump_kw = dump_kw or {}
         with _fname_or_fpointer(fname_or_handle, mode="w", encoding="utf-8") as fp:

--- a/src/dataclassio/types.py
+++ b/src/dataclassio/types.py
@@ -2,6 +2,7 @@ import dataclasses as dcs
 import io
 import os
 from enum import Enum
+from functools import total_ordering
 from pathlib import Path
 
 import typing_extensions as tp
@@ -19,10 +20,16 @@ PathLike: tp.TypeAlias = str | bytes | Path | os.PathLike
 PathOrHandle: tp.TypeAlias = PathLike | io.IOBase
 
 
+@total_ordering
 class ExtraFieldStrategy(Enum):
     STRICT = "strict"
     IGNORE = "ignore"
     CAPTURE = "capture"
+
+    def __lt__(self, other):
+        if not isinstance(other, ExtraFieldStrategy):
+            return NotImplemented
+        return self.value < other.value
 
 
 EFS = ExtraFieldStrategy

--- a/tests/test_basic_literals.py
+++ b/tests/test_basic_literals.py
@@ -55,7 +55,7 @@ class TestDictLiterals:
         actual = _schemas.User.from_dict(dikt_with_admin)
         expected = _schemas.User(2, "Bob", True)
         assert actual == expected
-        assert actual.to_dict(True) == dikt_with_admin
+        assert actual.to_dict(skip_defaults=True) == dikt_with_admin
 
     def test_plain_containers(self):
         dikt = {"id": 1, "name": "Alice", "metadata": {"k1": "k2"}, "data": [1, 2, 3]}

--- a/tests/test_config_propagation.py
+++ b/tests/test_config_propagation.py
@@ -1,0 +1,107 @@
+import dataclasses as dcs
+
+import pytest
+
+from dataclassio import EFS
+from dataclassio.config import FieldOpts
+from dataclassio.io_mixin import IOMixin
+
+
+@dcs.dataclass
+class InnerMost(IOMixin):
+    core: str
+
+
+@dcs.dataclass
+class Inner(IOMixin):
+    innermost: InnerMost
+
+
+@dcs.dataclass
+class Outer(IOMixin):
+    inner: Inner = dcs.field(metadata=FieldOpts(extra_field_strategy=EFS.CAPTURE))
+    inner2: Inner = dcs.field(metadata=FieldOpts(extra_field_strategy=EFS.STRICT))
+    inner3: Inner
+
+
+# Assuming the library components are imported as follows:
+# from dataclass_io import IOMixin, FieldOpts, EFS, from_dict
+
+
+class TestExtraFieldPropagation:
+    def test_capture_strategy_propagation(self):
+        """Test CASE 1: inner (EFS.CAPTURE) captures extras and propagates to child."""
+        payload = {
+            "inner": {
+                "extra_at_inner": "captured",
+                "innermost": {"core": "c1", "extra_at_innermost": "captured_too"},
+            },
+            "inner2": {"innermost": {"core": "c2"}},  # Clean to avoid STRICT error
+            "inner3": {"innermost": {"core": "c3"}},
+        }
+
+        obj = Outer.from_dict(payload)
+
+        # Verify capture on the field itself
+        assert obj.inner.extra_fields["extra_at_inner"] == "captured"
+        # Verify propagation to the inner dataclass
+        assert obj.inner.innermost.extra_fields["extra_at_innermost"] == "captured_too"
+
+    def test_strict_strategy_failure(self):
+        """Test CASE 2: inner2 (EFS.STRICT) raises ValueError if any extras exist."""
+        # Payload with extra field only in the STRICT branch
+        bad_payload = {
+            "inner": {"innermost": {"core": "c1"}},
+            "inner2": {"innermost": {"core": "c2", "forbidden": "error"}},
+            "inner3": {"innermost": {"core": "c3"}},
+        }
+
+        with pytest.raises(ValueError, match="extra fields"):
+            Outer.from_dict(bad_payload)
+
+    def test_ignore_strategy_silence(self):
+        """Test CASE 3: inner3 (Default/IGNORE) silently drops extra fields."""
+        payload = {
+            "inner": {"innermost": {"core": "c1"}},
+            "inner2": {"innermost": {"core": "c2"}},
+            "inner3": {"ignored_key": "bye", "innermost": {"core": "c3", "ignored_inner": "bye"}},
+        }
+
+        obj = Outer.from_dict(payload)
+
+        # Ensure no error was raised and no capture occurred
+        assert obj.inner3.innermost.core == "c3"
+        assert not obj.inner3.extra_fields
+        assert not obj.inner3.innermost.extra_fields
+
+    def test_strategy_isolation(self):
+        """Ensures strategies do not bleed between sibling fields."""
+        # If inner2 is clean, the whole object should parse even if inner has extras
+        payload = {
+            "inner": {"extra": "val", "innermost": {"core": "c1"}},
+            "inner2": {"innermost": {"core": "c2"}},
+            "inner3": {"innermost": {"core": "c3"}},
+        }
+
+        # This should NOT raise ValueError because inner2's branch is clean
+        obj = Outer.from_dict(payload)
+        assert obj.inner2.innermost.core == "c2"
+
+    def test_efs_hierarchy_precedence(self):
+        """
+        Ensures that Field-Level metadata takes highest priority over
+        global or type-level settings.
+        """
+        # Even if we pass EFS.STRICT globally, 'inner' should still CAPTURE
+        # because field-level metadata is Priority 1.
+        payload = {
+            "inner": {"extra": "captured", "innermost": {"core": "v"}},
+            "inner2": {"innermost": {"core": "v"}},
+            "inner3": {"innermost": {"core": "v"}},
+        }
+
+        # Providing a global override that would otherwise fail the whole call
+        obj = Outer.from_dict(payload, extra_field_strategy=EFS.STRICT)
+
+        # 'inner' should have succeeded despite global STRICT setting
+        assert obj.inner.extra_fields["extra"] == "captured"

--- a/tests/test_init_fields.py
+++ b/tests/test_init_fields.py
@@ -31,11 +31,11 @@ class TestInitFalseFields:
         expected = _sch.InitFalseDC(1.0, 2.0)
 
         # Business as usual
-        new_inst = _sch.InitFalseDC.from_dict(data, EFS.IGNORE)
+        new_inst = _sch.InitFalseDC.from_dict(data, extra_field_strategy=EFS.IGNORE)
         assert expected == new_inst
 
         # No exception despite the "extra" field
-        new_inst = _sch.InitFalseDC.from_dict(data, EFS.STRICT)
+        new_inst = _sch.InitFalseDC.from_dict(data, extra_field_strategy=EFS.STRICT)
         assert expected == new_inst
 
         # 'c' is not captured.

--- a/tests/test_unions.py
+++ b/tests/test_unions.py
@@ -1,0 +1,116 @@
+import dataclasses as dcs
+import typing as tp
+
+import pytest
+
+from dataclassio import IOMixin
+from dataclassio.config import FieldOpts
+
+
+@dcs.dataclass
+class HumanAnnotator:
+    id: str
+    type: tp.Literal["human_annotator", "human"] = "human_annotator"
+    team: str | None = None
+
+
+@dcs.dataclass
+class MachineAnnotator:
+    id: str
+    type: tp.Literal["machine_annotator"] = "machine_annotator"
+    algorithm_type: str | None = None
+
+
+@dcs.dataclass
+class AdminAnnotator:
+    id: str
+    type: tp.Literal["admin_annotator"] = "admin_annotator"
+    level: int = 1
+
+
+@dcs.dataclass
+class Dataset(IOMixin):
+    annotators: list[HumanAnnotator | MachineAnnotator | AdminAnnotator] = dcs.field(
+        default_factory=list, metadata=FieldOpts(discriminator="type")
+    )
+
+
+class TestDiscriminatedUnions:
+    def test_multiple_key_support(self):
+        payload = {
+            "annotators": [
+                {"id": "John Smith", "type": "human_annotator", "team": "ACME Corp"},
+                {"id": "Jane Doe", "type": "human", "team": "ACME Corp South"},
+            ]
+        }
+
+        ds = Dataset.from_dict(payload)
+
+        assert len(ds.annotators) == 2
+        assert isinstance(ds.annotators[0], HumanAnnotator)
+        assert ds.annotators[0].id == "John Smith"
+        assert ds.annotators[0].team == "ACME Corp"
+
+        assert isinstance(ds.annotators[1], HumanAnnotator)
+        assert ds.annotators[1].id == "Jane Doe"
+        assert ds.annotators[1].team == "ACME Corp South"
+
+    def test_basic_union_deserialization(self):
+        """Verify that a list with multiple types is correctly partitioned."""
+        payload = {
+            "annotators": [
+                {"id": "John Smith", "type": "human_annotator", "team": "ACME Corp"},
+                {"id": "COCO-Net", "type": "machine_annotator", "algorithm_type": "ResNet"},
+            ]
+        }
+
+        ds = Dataset.from_dict(payload)
+
+        assert len(ds.annotators) == 2
+        assert isinstance(ds.annotators[0], HumanAnnotator)
+        assert ds.annotators[0].id == "John Smith"
+        assert ds.annotators[0].team == "ACME Corp"
+
+        assert isinstance(ds.annotators[1], MachineAnnotator)
+        assert ds.annotators[1].id == "COCO-Net"
+        assert ds.annotators[1].algorithm_type == "ResNet"
+
+    def test_multi_member_union_support(self):
+        """Ensure more than two union members (e.g., 3) work as expected."""
+        payload = {"annotators": [{"id": "A1", "type": "admin_annotator", "level": 5}]}
+        ds = Dataset.from_dict(payload)
+        assert isinstance(ds.annotators[0], AdminAnnotator)
+        assert ds.annotators[0].level == 5
+
+    def test_missing_discriminator_field(self):
+        """Verify behavior when the required discriminator key is missing from the dictionary."""
+        payload = {"annotators": [{"id": "Incomplete", "team": "MissingType"}]}
+        # The generator should explicitly check for the discriminator
+        with pytest.raises(KeyError):
+            Dataset.from_dict(payload)
+
+    def test_invalid_discriminator_value(self):
+        """Verify behavior when the discriminator value doesn't match any Literal."""
+        payload = {"annotators": [{"id": "Ghost", "type": "alien_annotator"}]}
+        # Since 'type' is used to resolve the class, an unknown value should fail
+        with pytest.raises(KeyError, match="alien_annotator"):
+            Dataset.from_dict(payload)
+
+    def test_round_trip_serialization(self):
+        """Ensure to_dict produces a dictionary that can be re-parsed into the same union."""
+        original = Dataset(
+            annotators=[
+                HumanAnnotator(id="H1", team="A-Team"),
+                MachineAnnotator(id="M1", algorithm_type="YOLO"),
+            ]
+        )
+
+        exported = original.to_dict()
+
+        # Verify the 'type' field is correctly exported to enable the round-trip
+        assert exported["annotators"][0]["type"] == "human_annotator"
+        assert exported["annotators"][1]["type"] == "machine_annotator"
+
+        # Round trip
+        recovered = Dataset.from_dict(exported)
+        assert recovered == original


### PR DESCRIPTION
Closes #1, #2

This MR adds supports for field-level configuration (including overriding extra field strategy, and setting discriminator field names) and adds support for discriminated unions.

## Configuration

Previously, we had global defaults and call-level options. This MR adds field-level options which take precedence over both. In the future, it'd be cool to add type-level options which sit between the two OR sit between those and the global defaults. I think the current code is wired to support type-level options that have the second-lowest precedence: sitting just above the global defaults but below call- and field-level options.

This options percolate down a hierarchy as you would expect, allowing for different fields in a data class to, for instance, have different `EFS` settings.

## Discriminated Unions

Using the new field-level configuration settings, you can now set the name of a field that can be used to disambiguate the type of an object when parsing into a Union-typed field. For instance, this scenario is now supported:

```python
payload = {
    "annotators": [
        {"id": "John Smith", "type": "human_annotator", "team": "ACME Corp"},
        {"id": "COCO-Net", "type": "machine_annotator", "algorithm_type": "ResNet"},
    ]
}

@dcs.dataclass
class HumanAnnotator:
    id: str
    type: tp.Literal["human_annotator", "human"] = "human_annotator"
    team: str | None = None


@dcs.dataclass
class MachineAnnotator:
    id: str
    type: tp.Literal["machine_annotator"] = "machine_annotator"
    algorithm_type: str | None = None

@dcs.dataclass
class Dataset(IOMixin):
    annotators: list[HumanAnnotator | MachineAnnotator] = dcs.field(
        default_factory=list, metadata=FieldOpts(discriminator="type")
    )

ds = Dataset.from_dict(payload)
# annotators=[HumanAnnotator(...), MachineAnnotator(...)]
```