### PR TITLE
Fix codegen for self-referential types.

### DIFF
--- a/benchmarks/coco_bench.py
+++ b/benchmarks/coco_bench.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+import msgspec
+from pybench import Bench, BenchContext
+
+import dataclassio._example_schemas as sch
+from dataclassio.types import EFS
+
+
+def load_coco_dict() -> dict:
+    pth = (__file__ / Path("../../test_data/instances_val2017.json")).resolve()
+
+    with pth.open("rb") as fp:
+        buf = fp.read()
+    return msgspec.json.decode(buf)
+
+
+loaders = Bench("coco_roundtrip")
+
+coco_data = load_coco_dict()
+
+
+@loaders.bench(group="from_dict", name="from_dict_ignore")
+def test_dio():
+    sch.Coco.from_dict(coco_data)
+
+
+@loaders.bench(group="from_dict", name="from_dict_strict")
+def test_dio_strict():
+    sch.Coco.from_dict(coco_data, extra_field_strategy=EFS.STRICT)
+
+
+@loaders.bench(group="from_dict", name="from_dict_capture")
+def test_dio_capture():
+    sch.Coco.from_dict(coco_data, extra_field_strategy=EFS.CAPTURE)
+
+
+@loaders.bench(group="to_dict", name="to_dict_no_skip")
+def test_dio_to(b: BenchContext):
+    obj = sch.Coco.from_dict(coco_data)
+    b.start()
+    obj.to_dict(skip_if_default=False)
+    b.end()
+
+
+@loaders.bench(group="to_dict", name="to_dict_skip_defaults")
+def test_dio_to_skip(b: BenchContext):
+    obj = sch.Coco.from_dict(coco_data)
+    b.start()
+    obj.to_dict(skip_if_default=True)
+    b.end()

--- a/benchmarks/compare_with_other_libraries.py
+++ b/benchmarks/compare_with_other_libraries.py
@@ -27,34 +27,34 @@ coco_data = load_coco_dict()
 
 @loaders.bench(name="dataclassio", baseline=True)
 def test_dio():
-    return sch.Coco.from_dict(coco_data)
+    sch.Coco.from_dict(coco_data)
 
 
 @loaders.bench(name="dio_fast")
 def test_locals():
-    return sch.Coco.fast_from_dict(coco_data)
+    sch.Coco.fast_from_dict(coco_data)
 
 
 @loaders.bench(name="pydantic")
 def test_pyd():
-    return CocoPyd.model_validate(coco_data)
+    CocoPyd.model_validate(coco_data)
 
 
 @loaders.bench(name="msgspec_into_dataclass")
 def test_msgspec_into_dataclass():
-    return msgspec.convert(coco_data, sch.Coco)
+    msgspec.convert(coco_data, sch.Coco)
 
 
 @loaders.bench(name="msgspec_into_native")
 def test_msgspec_into_native():
-    return msgspec.convert(coco_data, CocoMsgSpec)
+    msgspec.convert(coco_data, CocoMsgSpec)
 
 
 @loaders.bench(name="mashumaro")
 def test_mashumaro():
-    return CocoMashumaro.from_dict(coco_data)
+    CocoMashumaro.from_dict(coco_data)
 
 
 @loaders.bench(name="dataclass-wizard")
 def test_dw():
-    return CocoDW.from_dict(coco_data)
+    CocoDW.from_dict(coco_data)

--- a/src/dataclassio/config.py
+++ b/src/dataclassio/config.py
@@ -133,5 +133,5 @@ def get_options_cache_key(
     relevant_keys = _FROM_KEYS if direction == "from_dict" else _TO_KEYS
     filtered_data = tp.cast(DioOptions, {k: v for k, v in options.items() if k in relevant_keys})
 
-    data = tuple(sorted(filtered_data.items()))
-    return data, _build_string(filtered_data)
+    key = _build_string(filtered_data)
+    return key, key

--- a/src/dataclassio/config.py
+++ b/src/dataclassio/config.py
@@ -2,6 +2,7 @@ from collections import ChainMap
 
 import typing_extensions as tp
 
+from .sentinels import NO_VALUE, NO_VALUE_T
 from .types import EFS
 
 __all__ = (
@@ -10,32 +11,18 @@ __all__ = (
     "get_composite_options",
     "get_passthrough_options",
     "get_options_cache_key",
-    "NoValue",
 )
-
-T = tp.TypeVar("T", bound=type)
-
-
-class _NoValue:
-    def __repr__(self) -> str:
-        return "<NoValueProvided>"
-
-    def __str__(self) -> str:
-        return "NoValueProvided"
-
-
-NoValue: tp.Final = _NoValue()
 
 
 class DioOptions(tp.TypedDict, total=False):
-    discriminator: str | _NoValue
+    discriminator: str | NO_VALUE_T
     extra_field_strategy: EFS
     skip_if_default: bool
     include_src_in_docstring: bool
 
 
 class _TotalDioOptions(DioOptions):
-    discriminator: str | _NoValue
+    discriminator: str | NO_VALUE_T
     extra_field_strategy: EFS
     skip_if_default: bool
     include_src_in_docstring: bool
@@ -47,7 +34,7 @@ def FieldOpts(**kw: tp.Unpack[DioOptions]):
 
 
 DIO_DEFAULT_OPTIONS = _TotalDioOptions(
-    discriminator=NoValue,
+    discriminator=NO_VALUE,
     extra_field_strategy=EFS.IGNORE,
     skip_if_default=False,
     include_src_in_docstring=False,

--- a/src/dataclassio/core/common.py
+++ b/src/dataclassio/core/common.py
@@ -4,7 +4,7 @@ import uuid
 
 import typing_extensions as tp
 
-from ..types import NO_DEFAULT
+from ..sentinels import NO_DEFAULT, NO_DEFAULT_T
 
 __all__ = (
     "get_fields",
@@ -33,7 +33,7 @@ def field_has_default(f: dcs.Field):
     return get_field_default(f, call_factory=False) is not NO_DEFAULT
 
 
-def get_field_default(f: dcs.Field, *, call_factory: bool = True):
+def get_field_default(f: dcs.Field, *, call_factory: bool = True) -> tp.Any | NO_DEFAULT_T:
     """Get the default value for a field, if any."""
     if f.default is not dcs.MISSING:
         return f.default

--- a/src/dataclassio/core/expression_builder.py
+++ b/src/dataclassio/core/expression_builder.py
@@ -5,12 +5,21 @@ from datetime import datetime
 
 import typing_extensions as tp
 
-from ..config import NoValue, _TotalDioOptions
-from ..sentinels import CYCLE_DETECTED, CYCLE_DETECTED_T
+from ..config import _TotalDioOptions
+from ..sentinels import CYCLE_DETECTED, CYCLE_DETECTED_T, NO_VALUE, NO_VALUE_T
 from ..types import FUNC_MAKER, DataclassInstance
 from .common import get_fields, make_variable_name, strip_optional
 
 __all__ = ("SerializerData", "build_expr", "get_field_expression")
+
+
+class ParserOutput(tp.NamedTuple):
+    parser: tp.Callable | CYCLE_DETECTED_T
+    fname: str
+
+    @property
+    def was_cycle(self):
+        return self.parser is CYCLE_DETECTED
 
 
 class SerializerData(tp.NamedTuple):
@@ -25,7 +34,7 @@ class SerializerData(tp.NamedTuple):
 
     def get_parser_and_fname_for_cls(
         self, kls: type[DataclassInstance], update_ns: bool = True
-    ) -> tuple[tp.Callable | CYCLE_DETECTED_T, str]:
+    ) -> ParserOutput:
         """Return a function for making a kls, and its suggested function name."""
         # Get the maker func
         parser = self.maker_func(kls)
@@ -37,7 +46,23 @@ class SerializerData(tp.NamedTuple):
         if update_ns:
             self.namespace[fname] = parser
 
-        return parser, fname
+        return ParserOutput(parser, fname)
+
+    def new_variable(self, name: str, value: tp.Any | NO_VALUE_T = NO_VALUE):
+        """Generate a new variable name which does not conflict with any in the namespace.
+
+        Args:
+            name: _Desired_ name of the variable. Extra characters will be appended to avoid
+                  conflicts, if necessary.
+            value: (Optional) value to assign to the variable in the current namespace.
+
+        Returns:
+            The assigned name for the variable.
+        """
+        assigned_fname = make_variable_name(name, ns=self.namespace)
+        if value is not NO_VALUE:
+            self.namespace[assigned_fname] = value
+        return assigned_fname
 
 
 def build_expr(
@@ -108,14 +133,13 @@ def build_expr(
             raise RuntimeError(msg)
         # check the field options.
         discriminator = serializer_data.options["discriminator"]
-        if discriminator is NoValue:
+        if discriminator is NO_VALUE:
             msg = (
                 f"type={t}, generated via {expr_str=} is not supported."
                 " A discriminator field was not provided."
             )
-        assert isinstance(discriminator, str)
+        # assert isinstance(discriminator, str)
 
-        # base case
         if serializer_data.func_prefix == "deserialize":
             # from_dict
             key_expr = f"{expr_str}[{discriminator!r}]"
@@ -124,7 +148,7 @@ def build_expr(
             key_expr = f"{expr_str}.{discriminator!s}"
 
         # build list of types:
-        maker_map_data: dict[str, str] = {}
+        maker_map_data: dict[str, ParserOutput] = {}
         for cls_option in args:
             fields = [f for f in get_fields(cls_option) if f.name == discriminator]
             if not fields:
@@ -147,7 +171,7 @@ def build_expr(
                 raise RuntimeError(msg)
 
             # Build the mapping of discriminator values to parsers.
-            _maker_func, fname = serializer_data.get_parser_and_fname_for_cls(cls_option)
+            parser_data = serializer_data.get_parser_and_fname_for_cls(cls_option)
 
             for arg_name in discrim_args:
                 if arg_name in maker_map_data:
@@ -156,13 +180,20 @@ def build_expr(
                         f"The union options have duplicate values for {discriminator}."
                     )
                     raise RuntimeError(msg)
-                maker_map_data[arg_name] = fname
+                maker_map_data[arg_name] = parser_data
 
-        disambiguator_data = ", ".join(f"{k!r}: {v!s}" for k, v in maker_map_data.items())
-        disambiguator_literal = f"{{ {disambiguator_data} }}"
-
-        # build the final expression:
-        return f"({disambiguator_literal}[{key_expr}]({expr_str}))"
+        if any(pd.was_cycle for pd in maker_map_data.values()):
+            # Bummer, got to do this the slow af way with late binding.
+            # If we ever support emitting _statements_, then we can do this more simply.
+            disambiguator_data = ", ".join(
+                f"{k!r}: {v.fname!s}" for k, v in maker_map_data.items()
+            )
+            fname = f"{{{disambiguator_data}}}"
+        else:
+            # nice. No reference cycles, so we an do this the normal way.
+            func_map = {k: v.parser for k, v in maker_map_data.items()}
+            fname = serializer_data.new_variable("_DISAMBIGUATOR", func_map)
+        return f"{fname}[{key_expr}]({expr_str})"
 
     # 2. Handle atoms (note that we don't recurse into `build_expr`)
     if dcs.is_dataclass(t):
@@ -188,8 +219,7 @@ def build_expr(
             return f"({expr_str}).isoformat()"
 
         # from dict
-        fname = make_variable_name("_fromisoformat")
-        serializer_data.namespace[fname] = datetime.fromisoformat
+        fname = serializer_data.new_variable("_fromisoformat", datetime.fromisoformat)
         return f"{fname}({expr_str})"
 
     # 3. Fallbacks

--- a/src/dataclassio/core/expression_builder.py
+++ b/src/dataclassio/core/expression_builder.py
@@ -27,7 +27,6 @@ class SerializerData(tp.NamedTuple):
         cache_data, postfix = self.cache_key
         cache_key = (kls, cache_data)
         if cache_key not in self.registry:
-            self.registry[cache_key] = None
             self.registry[cache_key] = self.maker_func(kls)
         maker_func = self.registry[cache_key]
 

--- a/src/dataclassio/core/expression_builder.py
+++ b/src/dataclassio/core/expression_builder.py
@@ -6,7 +6,8 @@ from datetime import datetime
 import typing_extensions as tp
 
 from ..config import NoValue, _TotalDioOptions
-from ..types import DataclassInstance
+from ..sentinels import CYCLE_DETECTED, CYCLE_DETECTED_T
+from ..types import FUNC_MAKER, DataclassInstance
 from .common import get_fields, make_variable_name, strip_optional
 
 __all__ = ("SerializerData", "build_expr", "get_field_expression")
@@ -17,27 +18,32 @@ class SerializerData(tp.NamedTuple):
 
     registry: tp.MutableMapping
     namespace: tp.MutableMapping
-    maker_func: tp.Callable[[type[DataclassInstance]], tp.Callable]
+    maker_func: FUNC_MAKER
     cache_key: tuple[tp.Hashable, str]
     options: _TotalDioOptions
+    func_prefix: tp.Literal["deserialize", "serialize"]
 
-    def get_dataclass_function(self, kls: type[DataclassInstance]) -> tuple[tp.Callable, str]:
-        """Return a function for making a kls, and its suggested rootname."""
+    def get_parser_and_fname_for_cls(
+        self, kls: type[DataclassInstance], update_ns: bool = True
+    ) -> tuple[tp.Callable | CYCLE_DETECTED_T, str]:
+        """Return a function for making a kls, and its suggested function name."""
         # Get the maker func
-        cache_data, postfix = self.cache_key
-        cache_key = (kls, cache_data)
-        if cache_key not in self.registry:
-            self.registry[cache_key] = self.maker_func(kls)
-        maker_func = self.registry[cache_key]
+        parser = self.maker_func(kls)
+        if parser is CYCLE_DETECTED:
+            # Fallback path. DO NOT add this crap to the global namespace.
+            update_ns = False
 
-        return maker_func, f"{kls.__name__}{postfix}"
+        fname = f"{self.func_prefix}_{kls.__name__}{self.cache_key[1]}"
+        if update_ns:
+            self.namespace[fname] = parser
+
+        return parser, fname
 
 
 def build_expr(
     t: tp.TypeForm,
     expr_str: str,
     serializer_data: SerializerData,
-    func_prefix: tp.Literal["deserialize", "serialize"] = "deserialize",
 ) -> str:
     """Create the expression to pack or unpack a type.
 
@@ -59,8 +65,6 @@ def build_expr(
         expr_str: string representation of how to access the value to pack or unpack.
             e.g., `"inst.attribute_name"` or `"dikt['attributeName']"`
         serializer_data: The structure to track information for parsing embedded dataclasses.
-        func_prefix: Prefix for dynamically created functions to pack or unpack embedded
-            dataclasses.
     """
     if isinstance(t, dcs.InitVar):
         # Strip the InitVar wrapper
@@ -71,18 +75,14 @@ def build_expr(
 
     # 1. Handle composite types (e.g., Optionals and containers)
     if is_optional:
-        inner_expr = build_expr(
-            stripped_type, expr_str, serializer_data=serializer_data, func_prefix=func_prefix
-        )
+        inner_expr = build_expr(stripped_type, expr_str, serializer_data=serializer_data)
         if inner_expr == expr_str:
             return expr_str
         return f"({inner_expr} if {expr_str} is not None else None)"
 
     if origin in (list, tp.List):
         inner_type = args[0] if args else tp.Any
-        inner_expr = build_expr(
-            inner_type, "x", serializer_data=serializer_data, func_prefix=func_prefix
-        )
+        inner_expr = build_expr(inner_type, "x", serializer_data=serializer_data)
         if inner_expr == "x":
             # No list comprehension needed.
             return expr_str
@@ -90,8 +90,8 @@ def build_expr(
 
     if origin in (dict, tp.Mapping):
         k_type, v_type = args if args else (tp.Any, tp.Any)
-        k_expr = build_expr(k_type, "k", serializer_data=serializer_data, func_prefix=func_prefix)
-        v_expr = build_expr(v_type, "v", serializer_data=serializer_data, func_prefix=func_prefix)
+        k_expr = build_expr(k_type, "k", serializer_data=serializer_data)
+        v_expr = build_expr(v_type, "v", serializer_data=serializer_data)
         if k_expr == "k" and v_expr == "v":
             # No subparsing necesary, just return as is.
             return expr_str
@@ -116,15 +116,15 @@ def build_expr(
         assert isinstance(discriminator, str)
 
         # base case
-        if func_prefix == "deserialize":
+        if serializer_data.func_prefix == "deserialize":
             # from_dict
-            inner_expr = f"{expr_str}[{discriminator!r}]"
+            key_expr = f"{expr_str}[{discriminator!r}]"
         else:
             # to_dict
-            inner_expr = f"{expr_str}.{discriminator!s}"
+            key_expr = f"{expr_str}.{discriminator!s}"
 
         # build list of types:
-        maker_map_data: dict[str, tp.Any] = {}
+        maker_map_data: dict[str, str] = {}
         for cls_option in args:
             fields = [f for f in get_fields(cls_option) if f.name == discriminator]
             if not fields:
@@ -146,8 +146,8 @@ def build_expr(
                 )
                 raise RuntimeError(msg)
 
-            # Get the maker func
-            maker_func, _ = serializer_data.get_dataclass_function(cls_option)
+            # Build the mapping of discriminator values to parsers.
+            _maker_func, fname = serializer_data.get_parser_and_fname_for_cls(cls_option)
 
             for arg_name in discrim_args:
                 if arg_name in maker_map_data:
@@ -156,24 +156,22 @@ def build_expr(
                         f"The union options have duplicate values for {discriminator}."
                     )
                     raise RuntimeError(msg)
-                maker_map_data[arg_name] = maker_func
+                maker_map_data[arg_name] = fname
 
-        fname = make_variable_name("_DISAMBIGUATOR", ns=serializer_data.namespace)
-        serializer_data.namespace[fname] = maker_map_data
+        disambiguator_data = ", ".join(f"{k!r}: {v!s}" for k, v in maker_map_data.items())
+        disambiguator_literal = f"{{ {disambiguator_data} }}"
+
         # build the final expression:
-        return f"{fname}[{inner_expr}]({expr_str})"
+        return f"({disambiguator_literal}[{key_expr}]({expr_str}))"
 
     # 2. Handle atoms (note that we don't recurse into `build_expr`)
     if dcs.is_dataclass(t):
-        maker_func, root_name = serializer_data.get_dataclass_function(t)
-
-        fname = make_variable_name(f"{func_prefix}_{root_name}")
-        serializer_data.namespace[fname] = maker_func
+        _, fname = serializer_data.get_parser_and_fname_for_cls(t, update_ns=True)
         return f"{fname}({expr_str})"
 
     if isinstance(t, type) and issubclass(t, enum.Enum):
         # For enum types, convert to the Enum.
-        if func_prefix == "serialize":
+        if serializer_data.func_prefix == "serialize":
             # To Dict
             return f"{expr_str}.value"
 
@@ -182,10 +180,10 @@ def build_expr(
         serializer_data.namespace[enum_name] = t  # Ensure the Enum type is in the namespace.
 
         # N.B. Doing `v if isinstance(v := {expr_str}, Enum) else Enum(v)` is slower than this.
-        return f"{enum_name}({expr_str})"
+        return f"({enum_name}({expr_str}))"
 
     if t is datetime:
-        if func_prefix == "serialize":
+        if serializer_data.func_prefix == "serialize":
             # To dict
             return f"({expr_str}).isoformat()"
 
@@ -198,11 +196,7 @@ def build_expr(
     return expr_str
 
 
-def get_field_expression(
-    f: dcs.Field,
-    serializer_data: SerializerData,
-    direction: tp.Literal["to_dict", "from_dict"] = "from_dict",
-) -> str:
+def get_field_expression(f: dcs.Field, serializer_data: SerializerData) -> str:
     """Create the expression to pack or unpack a dataclass field.
 
     This is mostly a convenience wrapper around `build_expr`.
@@ -210,18 +204,13 @@ def get_field_expression(
     Args:
         f: The dataclasses.Field to parse.
         serializer_data: The structure to track information for parsing embedded dataclasses.
-        direction: Whether to create an expression for serializing (to_dict) or deserializing (from_dict).
     """
-    if direction == "from_dict":
-        access_expr = f"dikt[{f.name!r}]"
-        func_prefix = "deserialize"
-    elif direction == "to_dict":
+    if serializer_data.func_prefix == "serialize":
         access_expr = f"inst.{f.name}"
-        func_prefix = "serialize"
+    elif serializer_data.func_prefix == "deserialize":
+        access_expr = f"dikt[{f.name!r}]"
     else:
-        msg = f"Unknown {direction=}. Expected 'to_dict' or 'from_dict'."
+        msg = f"Unsupported {serializer_data.func_prefix=}. Expected 'deserialize' or 'serialize'."
         raise ValueError(msg)
 
-    return build_expr(
-        f.type, access_expr, serializer_data=serializer_data, func_prefix=func_prefix
-    )
+    return build_expr(f.type, access_expr, serializer_data=serializer_data)

--- a/src/dataclassio/core/lines.py
+++ b/src/dataclassio/core/lines.py
@@ -5,18 +5,13 @@ import typing_extensions as tp
 __all__ = ("TextLines",)
 
 
-class TextLines(tp.Sequence[str]):
+class TextLines:
     """Object to manage (possibly) indented strings."""
 
-    def __init__(
-        self, initial: "TextLines | tp.Iterable[str] | None" = None, *, spacer: str = "  "
-    ):
+    def __init__(self, *, spacer: str = "  "):
         self._lines: list[str] = []
         self._spacer = spacer
         self._indent_level = 0
-
-        if initial is not None:
-            self.extend(initial)
 
     def append(self, line: str, /):
         self._lines.append(f"{self._spacer * self._indent_level}{line}")
@@ -45,10 +40,6 @@ class TextLines(tp.Sequence[str]):
         """Export this class as a block of text."""
         return sep.join(self._lines)
 
-    def reset(self) -> None:
-        self._lines.clear()
-        self._indent_level = 0
-
     def __str__(self):
         return self.export()
 
@@ -57,22 +48,6 @@ class TextLines(tp.Sequence[str]):
 
     def __len__(self):
         return len(self._lines)
-
-    @tp.overload
-    def __getitem__(self, idx: int) -> str: ...
-
-    @tp.overload
-    def __getitem__(self, idx: slice) -> "TextLines": ...
-
-    def __getitem__(self, idx: int | slice) -> "str | TextLines":
-        ret = self._lines[idx]
-        if isinstance(ret, str):
-            return ret
-        # must be a list.
-        return TextLines(ret)
-
-    def __setitem__(self, idx, val):
-        self._lines[idx] = val
 
     def __bool__(self):
         return bool(self._lines)

--- a/src/dataclassio/functional/__init__.py
+++ b/src/dataclassio/functional/__init__.py
@@ -9,7 +9,9 @@ __all__ = (
     "make_from_dict_source_code",
     "make_to_dict",
     "make_to_dict_source_code",
+    "from_dict",
+    "to_dict",
 )
 
-from .from_dict import make_from_dict, make_from_dict_source_code
-from .to_dict import make_to_dict, make_to_dict_source_code
+from .from_dict import from_dict, make_from_dict, make_from_dict_source_code
+from .to_dict import make_to_dict, make_to_dict_source_code, to_dict

--- a/src/dataclassio/functional/_shared.py
+++ b/src/dataclassio/functional/_shared.py
@@ -10,9 +10,64 @@ from dataclassio.config import (
 )
 from dataclassio.core.common import get_fields
 from dataclassio.core.lines import TextLines
+from dataclassio.sentinels import CYCLE_DETECTED, CYCLE_DETECTED_T, IN_PROGRESS
 from dataclassio.types import DataclassInstance
 
-IN_PROGRESS = tp.Sentinel("IN_PROGRESS")
+
+def maker_core(
+    cls: type[DataclassInstance],
+    registry: dict,
+    maker_func: tp.Callable[..., TextLines],
+    func_prefix: tp.Literal["serialize", "deserialize"],
+    direction: tp.Literal["to_dict", "from_dict"],
+    *,
+    options: _TotalDioOptions | DioOptions | None = None,
+    _field_options: _TotalDioOptions | DioOptions | None = None,
+    _ns: dict | None = None,
+    **kw: tp.Unpack[DioOptions],
+) -> tp.Callable | CYCLE_DETECTED_T:
+    if _ns is None:
+        # DO NOT use `_ns = _ns or None` since we don't want to
+        #  change the reference when _ns is merely the empty dict.
+        _ns = {}
+
+    call_options = options or {}
+    call_options.update(kw)
+    opts = get_composite_options(_field_options, call_options)
+    key, str_key = get_options_cache_key(opts, direction)
+
+    # Look for the function in the registry. If it doesn't exist, mark it as IN_PROGRESS.
+    # When the function is fully generated, we will overwrite it later.
+    func = registry.get((cls, key))
+    if func is IN_PROGRESS:
+        return CYCLE_DETECTED
+    if func is not None:
+        return func
+    registry[(cls, key)] = IN_PROGRESS
+
+    validate_type_hints(cls)
+
+    func_name = f"{func_prefix}_{cls.__name__}{str_key}"
+    src = maker_func(
+        cls,
+        funcname=func_name,
+        call_options=call_options,
+        _field_options=_field_options,
+        _ns=_ns,
+    )
+
+    file_name = f"dataclassio/generated/{func_name}.py"
+    code_obj = cache_source_code(src, file_name)
+    exec(code_obj, _ns)
+    func = _ns[func_name]
+
+    if opts["include_src_in_docstring"]:
+        func.__doc__ = func.__doc__ or ""
+        func.__doc__ += f"\n\n{src[2:]!s}\n"
+
+    registry[(cls, key)] = func
+    _ns[func_name] = func  # ensure the compiled function is itself in the global namespace.
+    return func
 
 
 def cache_source_code(src_code: TextLines, file_name: str):
@@ -26,49 +81,6 @@ def cache_source_code(src_code: TextLines, file_name: str):
     linecache.cache[file_name] = (len(src_str), None, src_str.splitlines(True), file_name)
 
     return code_obj
-
-
-def maker_core(
-    cls: type[DataclassInstance],
-    registry: dict,
-    maker_func: tp.Callable[..., tuple[TextLines, dict[str, tp.Any]]],
-    func_prefix: tp.Literal["serialize", "deserialize"],
-    direction: tp.Literal["to_dict", "from_dict"],
-    *,
-    options: _TotalDioOptions | DioOptions | None = None,
-    _field_options: _TotalDioOptions | DioOptions | None = None,
-    **kw: tp.Unpack[DioOptions],
-) -> tp.Callable:
-    call_options = options or {}
-    call_options.update(kw)
-
-    opts = get_composite_options(_field_options, call_options)
-    key, str_key = get_options_cache_key(opts, direction)
-
-    # Look for the function in the registry. If it doesn't exist, mark it as IN_PROGRESS.
-    # When the function is fully generated, we will overwrite it later.
-    f = registry.setdefault((cls, key), IN_PROGRESS)
-    if f is not IN_PROGRESS:
-        return f
-
-    validate_type_hints(cls)
-
-    func_name = f"{func_prefix}_{cls.__name__}{str_key}"
-    src, ns = maker_func(
-        cls, funcname=func_name, call_options=call_options, _field_options=_field_options
-    )
-
-    file_name = f"dataclassio/generated/{func_name}.py"
-    code_obj = cache_source_code(src, file_name)
-    exec(code_obj, ns)
-    func = ns[func_name]
-
-    if opts["include_src_in_docstring"]:
-        func.__doc__ = func.__doc__ or ""
-        func.__doc__ += f"\n\n{src[2:]!s}\n"
-
-    registry[(cls, key)] = func
-    return func
 
 
 def validate_type_hints(kls: type[DataclassInstance]):

--- a/src/dataclassio/functional/_shared.py
+++ b/src/dataclassio/functional/_shared.py
@@ -8,8 +8,11 @@ from dataclassio.config import (
     get_composite_options,
     get_options_cache_key,
 )
+from dataclassio.core.common import get_fields
 from dataclassio.core.lines import TextLines
 from dataclassio.types import DataclassInstance
+
+IN_PROGRESS = tp.Sentinel("IN_PROGRESS")
 
 
 def cache_source_code(src_code: TextLines, file_name: str):
@@ -28,22 +31,27 @@ def cache_source_code(src_code: TextLines, file_name: str):
 def maker_core(
     cls: type[DataclassInstance],
     registry: dict,
-    maker_func: tp.Callable,
+    maker_func: tp.Callable[..., tuple[TextLines, dict[str, tp.Any]]],
     func_prefix: tp.Literal["serialize", "deserialize"],
     direction: tp.Literal["to_dict", "from_dict"],
     *,
     options: _TotalDioOptions | DioOptions | None = None,
     _field_options: _TotalDioOptions | DioOptions | None = None,
     **kw: tp.Unpack[DioOptions],
-):
+) -> tp.Callable:
     call_options = options or {}
     call_options.update(kw)
 
     opts = get_composite_options(_field_options, call_options)
     key, str_key = get_options_cache_key(opts, direction)
 
-    if (f := registry.get((cls, key), None)) is not None:
+    # Look for the function in the registry. If it doesn't exist, mark it as IN_PROGRESS.
+    # When the function is fully generated, we will overwrite it later.
+    f = registry.setdefault((cls, key), IN_PROGRESS)
+    if f is not IN_PROGRESS:
         return f
+
+    validate_type_hints(cls)
 
     func_name = f"{func_prefix}_{cls.__name__}{str_key}"
     src, ns = maker_func(
@@ -61,3 +69,14 @@ def maker_core(
 
     registry[(cls, key)] = func
     return func
+
+
+def validate_type_hints(kls: type[DataclassInstance]):
+    # Check if fields were forward reference
+    fields = get_fields(kls, include_all=True)
+
+    forward_ref_fields = [f for f in fields if isinstance(f.type, str)]
+    if forward_ref_fields:
+        resolved_annotations = tp.get_annotations(kls, eval_str=True, format=tp.Format.VALUE)
+        for f in forward_ref_fields:
+            f.type = resolved_annotations[f.name]

--- a/src/dataclassio/functional/from_dict.py
+++ b/src/dataclassio/functional/from_dict.py
@@ -1,5 +1,6 @@
 import dataclasses as dcs
 import inspect
+from functools import partial
 
 import typing_extensions as tp
 
@@ -19,6 +20,7 @@ from ..core import (
     make_variable_name,
     parse_default_expression,
 )
+from ..sentinels import CYCLE_DETECTED, CYCLE_DETECTED_T
 from ..types import EFS, DataclassInstance, TDataclass
 from ._shared import maker_core
 
@@ -54,12 +56,16 @@ def make_from_dict_source_code(
     funcname: str = "",
     call_options: _TotalDioOptions | DioOptions | None = None,
     _field_options: _TotalDioOptions | DioOptions | None = None,
-) -> tuple[TextLines, dict[str, tp.Any]]:
+    _ns: dict[str, tp.Any] | None = None,
+) -> TextLines:
     """Generate the source code and necessary namespace for a from_dict deserialization method."""
     funcname = funcname or f"deserialize_{cls.__name__}"
-    cls_factory_name = make_variable_name("cls")
-    ns: dict[str, tp.Any] = {cls_factory_name: cls}
-    current_variable_names: set = {cls_factory_name, "dikt", "_exc"}
+    if _ns is None:
+        _ns = {}
+
+    cls_factory_name = make_variable_name("cls", ns=_ns)
+    _ns[cls_factory_name] = cls
+    current_variable_names: set[str] = {*_ns, "dikt", "_exc"}
 
     fields = get_fields(cls, include_all=True)
     field_data: dict[str, FieldSpec] = {}
@@ -86,19 +92,22 @@ def make_from_dict_source_code(
         # Get the expression for parsing this field.
         field_expr = get_field_expression(
             f,
-            direction="from_dict",
             serializer_data=SerializerData(
                 registry=_KNOWN_DESERIALIZERS,
-                namespace=ns,
-                maker_func=lambda t, m=passthrough_field_opts: make_from_dict(
-                    t, options=call_options, _field_options=m
+                namespace=_ns,
+                maker_func=partial(
+                    make_from_dict,
+                    options=call_options,
+                    _field_options=passthrough_field_opts,
+                    _ns=_ns,
                 ),
                 cache_key=cache_key,
                 options=resolved_options,
+                func_prefix="deserialize",
             ),
         )
 
-        var_name = make_variable_name(f.name, ns=current_variable_names.union(ns))
+        var_name = make_variable_name(f.name, ns=current_variable_names.union(_ns))
         current_variable_names.add(var_name)
 
         field_data[f.name] = FieldSpec(
@@ -128,7 +137,7 @@ def make_from_dict_source_code(
                 with lines.indent(f"if {fs.name!r} in dikt:"):
                     lines.append(f"{fs.var_name} = {fs.expr}")
                 with lines.indent("else:"):
-                    default_expr = parse_default_expression(fs.field, ns)
+                    default_expr = parse_default_expression(fs.field, _ns)
                     lines.append(f"{fs.var_name} = {default_expr}")
 
         # Now we need to build the constructor string. At this point, we have a local variable
@@ -149,9 +158,10 @@ def make_from_dict_source_code(
         data_str = ", ".join(init_parts)
 
         extras = _handle_extra_fields(
+            cls,
             fields,
             local_options["extra_field_strategy"],
-            ns=ns,
+            ns=_ns,
             attribute_name=_EXTRA_FIELD_ATTR_NAME,
         )
         if extras:
@@ -161,7 +171,7 @@ def make_from_dict_source_code(
         else:
             lines.append(f"return {cls_factory_name}({data_str})")
 
-    return lines, ns
+    return lines
 
 
 def make_from_dict(
@@ -169,8 +179,9 @@ def make_from_dict(
     *,
     options: _TotalDioOptions | DioOptions | None = None,
     _field_options: _TotalDioOptions | DioOptions | None = None,
+    _ns: dict[str, tp.Any] | None = None,
     **kw: tp.Unpack[DioOptions],
-) -> tp.Callable[[tp.Mapping[str, tp.Any]], TDataclass]:
+) -> tp.Callable[[tp.Mapping[str, tp.Any]], TDataclass] | CYCLE_DETECTED_T:
     """Make a from_dict deserialization method for the given dataclass.
 
     Args:
@@ -189,11 +200,13 @@ def make_from_dict(
         "from_dict",
         options=options,
         _field_options=_field_options,
+        _ns=_ns,
         **kw,
     )
 
 
 def _handle_extra_fields(
+    cls: type[DataclassInstance],
     fields: tp.Iterable[dcs.Field],
     strategy: EFS,
     *,
@@ -210,7 +223,7 @@ def _handle_extra_fields(
     # Precompute a lookup table with the known fields for this class.
     #  N.B. This will include init=False fields, thus preventing them from being counted
     #       as an extra.
-    field_names_set_varname = "_KNOWN_FIELDS"
+    field_names_set_varname = f"_KNOWN_FIELDS_{cls.__name__}"
     ns[field_names_set_varname] = frozenset(f.name for f in fields)
 
     extra_field_expr = (
@@ -254,4 +267,7 @@ def from_dict(
         A dataclass instance.
     """
     loader = make_from_dict(kls, options=options, **kw)
+    if loader is CYCLE_DETECTED:
+        msg = "Could not build deserializer due to reference cycle"
+        raise RuntimeError(msg)
     return loader(dikt)

--- a/src/dataclassio/functional/from_dict.py
+++ b/src/dataclassio/functional/from_dict.py
@@ -19,12 +19,13 @@ from ..core import (
     make_variable_name,
     parse_default_expression,
 )
-from ..types import EFS, DataclassInstance
+from ..types import EFS, DataclassInstance, TDataclass
 from ._shared import maker_core
 
 __all__ = (
     "make_from_dict_source_code",
     "make_from_dict",
+    "from_dict",
 )
 
 _KNOWN_DESERIALIZERS: dict[tuple[type, tp.Any], tp.Callable[[tp.Mapping], tp.Any]] = {}
@@ -164,12 +165,12 @@ def make_from_dict_source_code(
 
 
 def make_from_dict(
-    cls: type[DataclassInstance],
+    cls: type[TDataclass],
     *,
     options: _TotalDioOptions | DioOptions | None = None,
     _field_options: _TotalDioOptions | DioOptions | None = None,
     **kw: tp.Unpack[DioOptions],
-):
+) -> tp.Callable[[tp.Mapping[str, tp.Any]], TDataclass]:
     """Make a from_dict deserialization method for the given dataclass.
 
     Args:
@@ -231,3 +232,26 @@ def _handle_extra_fields(
 
     msg = f"Unexpected {strategy=}. Must be an ExtraFieldStrategy enumeration."
     raise ValueError(msg)
+
+
+def from_dict(
+    kls: type[TDataclass],
+    dikt: tp.Mapping[str, tp.Any],
+    *,
+    options: _TotalDioOptions | DioOptions | None = None,
+    **kw: tp.Unpack[DioOptions],
+) -> TDataclass:
+    """Load a dictionary into a Dataclass.
+
+    Args:
+        cls: The type of the dataclass to generate
+        dikt: The mapping of data used to populate the dataclass.
+        options: `DioOptions` to use to customize the code generation process. These may also
+            be provided via **kwargs. These propagate through to the fields of this dataclass
+            type.
+
+    Returns:
+        A dataclass instance.
+    """
+    loader = make_from_dict(kls, options=options, **kw)
+    return loader(dikt)

--- a/src/dataclassio/functional/to_dict.py
+++ b/src/dataclassio/functional/to_dict.py
@@ -15,7 +15,7 @@ from ..core import (
     get_fields,
     parse_default_expression,
 )
-from ..types import DataclassInstance
+from ..types import DataclassInstance, TDataclass
 from ._shared import maker_core
 from .from_dict import _EXTRA_FIELD_ATTR_NAME
 
@@ -120,12 +120,12 @@ def make_to_dict_source_code(
 
 
 def make_to_dict(
-    cls: type[DataclassInstance],
+    cls: type[TDataclass],
     *,
     options: _TotalDioOptions | DioOptions | None = None,
     _field_options: _TotalDioOptions | DioOptions | None = None,
     **kw: tp.Unpack[DioOptions],
-):
+) -> tp.Callable[[TDataclass], dict[str, tp.Any]]:
     """Make a to_dict serialization method for the given dataclass.
 
     Args:
@@ -146,3 +146,24 @@ def make_to_dict(
         _field_options=_field_options,
         **kw,
     )
+
+
+def to_dict(
+    obj: DataclassInstance,
+    *,
+    options: _TotalDioOptions | DioOptions | None = None,
+    **kw: tp.Unpack[DioOptions],
+):
+    """Convert a dataclass into a dictionary, recursively.
+
+    Args:
+        cls: The Dataclass instance to dump.
+        options: `DioOptions` to use to customize the code generation process. These may also
+            be provided via **kwargs. These propagate through to the fields of this dataclass
+            type.
+
+    Returns:
+        A dictionary representation of the instance.
+    """
+    dumper = make_to_dict(type(obj), options=options, **kw)
+    return dumper(obj)

--- a/src/dataclassio/functional/to_dict.py
+++ b/src/dataclassio/functional/to_dict.py
@@ -1,5 +1,7 @@
 import typing_extensions as tp
 
+from dataclassio.sentinels import CYCLE_DETECTED, CYCLE_DETECTED_T
+
 from ..config import (
     DioOptions,
     _TotalDioOptions,
@@ -28,9 +30,11 @@ def make_to_dict_source_code(
     funcname: str = "",
     call_options: _TotalDioOptions | DioOptions | None = None,
     _field_options: _TotalDioOptions | DioOptions | None = None,
-) -> tuple[TextLines, dict[str, tp.Any]]:
+    _ns: dict | None = None,
+) -> TextLines:
     funcname = funcname or f"serialize_{cls.__name__}"
-    ns: dict[str, tp.Any] = {}
+    if _ns is None:
+        _ns = {}
 
     # Currently unused. Maybe in the future?
     # local_options = get_composite_options(_field_options, call_options)
@@ -60,15 +64,15 @@ def make_to_dict_source_code(
 
         field_expr = get_field_expression(
             f,
-            direction="to_dict",
             serializer_data=SerializerData(
                 registry=_KNOWN_SERIALIZERS,
-                namespace=ns,
+                namespace=_ns,
                 maker_func=lambda t, m=passthrough_field_opts: make_to_dict(
                     t, options=call_options, _field_options=m
                 ),
                 cache_key=cache_key,
                 options=resolved_options,
+                func_prefix="serialize",
             ),
         )
 
@@ -82,7 +86,7 @@ def make_to_dict_source_code(
         if resolved_options["skip_if_default"] and field_has_default(f):
             # Add a hardcoded gate that checks if we have a default value. If so, don't
             #  add anything to the dict.
-            default_expression = parse_default_expression(f, ns, precompute_factory=False)
+            default_expression = parse_default_expression(f, _ns, precompute_factory=False)
             comparator = "is not" if default_expression == "None" else "!="
 
             with default_check_lines.indent(
@@ -116,7 +120,7 @@ def make_to_dict_source_code(
         lines.extend(default_check_lines)
         lines.append("return dikt")
 
-    return lines, ns
+    return lines
 
 
 def make_to_dict(
@@ -124,8 +128,9 @@ def make_to_dict(
     *,
     options: _TotalDioOptions | DioOptions | None = None,
     _field_options: _TotalDioOptions | DioOptions | None = None,
+    _ns: dict | None = None,
     **kw: tp.Unpack[DioOptions],
-) -> tp.Callable[[TDataclass], dict[str, tp.Any]]:
+) -> tp.Callable[[TDataclass], dict[str, tp.Any]] | CYCLE_DETECTED_T:
     """Make a to_dict serialization method for the given dataclass.
 
     Args:
@@ -144,6 +149,7 @@ def make_to_dict(
         "to_dict",
         options=options,
         _field_options=_field_options,
+        _ns=_ns,
         **kw,
     )
 
@@ -166,4 +172,7 @@ def to_dict(
         A dictionary representation of the instance.
     """
     dumper = make_to_dict(type(obj), options=options, **kw)
+    if dumper is CYCLE_DETECTED:
+        msg = "Could not generate a serializer due to a unresolved reference cycle."
+        raise RuntimeError(msg)
     return dumper(obj)

--- a/src/dataclassio/io_mixin.py
+++ b/src/dataclassio/io_mixin.py
@@ -5,8 +5,8 @@ from dataclasses import dataclass
 
 import typing_extensions as tp
 
+from . import functional as diof
 from .config import DioOptions
-from .functional import make_from_dict, make_to_dict
 from .functional.from_dict import _EXTRA_FIELD_ATTR_NAME
 from .types import PathOrHandle
 
@@ -65,10 +65,7 @@ class IOMixin:
         **kw: tp.Unpack[DioOptions],
     ) -> tp.Self:
         """Initialize this class from a dictionary."""
-
-        # Rely on internal cache.
-        method = make_from_dict(cls, options=options, **kw)
-        return method(dikt)
+        return diof.from_dict(cls, dikt, options=options, **kw)
 
     def to_dict(
         self,
@@ -81,10 +78,7 @@ class IOMixin:
         Returns:
             A dictionary representation of this class.
         """
-        # Rely on internal cache.
-        cls = self.__class__
-        method = make_to_dict(cls, options=options, **kw)
-        return method(self)
+        return diof.to_dict(self, options=options, **kw)
 
     def to_json_file(
         self,

--- a/src/dataclassio/sentinels.py
+++ b/src/dataclassio/sentinels.py
@@ -1,0 +1,23 @@
+from enum import Enum, auto
+
+import typing_extensions as tp
+
+
+class _Sentinels(Enum):
+    NO_DEFAULT = auto()
+    NO_VALUE = auto()
+    IN_PROGRESS = auto()
+    CYCLE_DETECTED = auto()
+
+
+NO_DEFAULT: tp.Final = _Sentinels.NO_DEFAULT
+NO_DEFAULT_T: tp.TypeAlias = tp.Literal[_Sentinels.NO_DEFAULT]
+
+NO_VALUE: tp.Final = _Sentinels.NO_VALUE
+NO_VALUE_T: tp.TypeAlias = tp.Literal[_Sentinels.NO_VALUE]
+
+IN_PROGRESS: tp.Final = _Sentinels.IN_PROGRESS
+IN_PROGRESS_T: tp.TypeAlias = tp.Literal[_Sentinels.IN_PROGRESS]
+
+CYCLE_DETECTED: tp.Final = _Sentinels.CYCLE_DETECTED
+CYCLE_DETECTED_T: tp.TypeAlias = tp.Literal[_Sentinels.CYCLE_DETECTED]

--- a/src/dataclassio/types.py
+++ b/src/dataclassio/types.py
@@ -2,7 +2,6 @@ import dataclasses as dcs
 import io
 import os
 from enum import Enum
-from functools import total_ordering
 from pathlib import Path
 
 import typing_extensions as tp
@@ -20,29 +19,18 @@ __all__ = (
 )
 
 
-PathLike: tp.TypeAlias = str | bytes | Path | os.PathLike
-PathOrHandle: tp.TypeAlias = PathLike | io.IOBase
-
-
 class DataclassInstance(tp.Protocol):
     __dataclass_fields__: tp.ClassVar[dict[str, dcs.Field]]
 
 
-TDataclass = tp.TypeVar("TDataclass", bound=DataclassInstance)
-
-
-@total_ordering
 class ExtraFieldStrategy(Enum):
     STRICT = "strict"
     IGNORE = "ignore"
     CAPTURE = "capture"
 
-    def __lt__(self, other):
-        if not isinstance(other, ExtraFieldStrategy):
-            return NotImplemented
-        return self.value < other.value
 
-
+PathLike: tp.TypeAlias = str | bytes | Path | os.PathLike
+PathOrHandle: tp.TypeAlias = PathLike | io.IOBase
 EFS = ExtraFieldStrategy
-
+TDataclass = tp.TypeVar("TDataclass", bound=DataclassInstance)
 FUNC_MAKER = tp.Callable[..., tp.Callable | CYCLE_DETECTED_T]

--- a/src/dataclassio/types.py
+++ b/src/dataclassio/types.py
@@ -7,19 +7,28 @@ from pathlib import Path
 
 import typing_extensions as tp
 
+from .sentinels import CYCLE_DETECTED_T
+
 __all__ = (
     "PathLike",
     "PathOrHandle",
     "ExtraFieldStrategy",
     "EFS",
     "DataclassInstance",
-    "NO_DEFAULT",
     "TDataclass",
+    "FUNC_MAKER",
 )
 
 
 PathLike: tp.TypeAlias = str | bytes | Path | os.PathLike
 PathOrHandle: tp.TypeAlias = PathLike | io.IOBase
+
+
+class DataclassInstance(tp.Protocol):
+    __dataclass_fields__: tp.ClassVar[dict[str, dcs.Field]]
+
+
+TDataclass = tp.TypeVar("TDataclass", bound=DataclassInstance)
 
 
 @total_ordering
@@ -36,11 +45,4 @@ class ExtraFieldStrategy(Enum):
 
 EFS = ExtraFieldStrategy
 
-
-class DataclassInstance(tp.Protocol):
-    __dataclass_fields__: tp.ClassVar[dict[str, dcs.Field]]
-
-
-TDataclass = tp.TypeVar("TDataclass", bound=DataclassInstance)
-
-NO_DEFAULT = tp.Sentinel("NO_DEFAULT")
+FUNC_MAKER = tp.Callable[..., tp.Callable | CYCLE_DETECTED_T]

--- a/src/dataclassio/types.py
+++ b/src/dataclassio/types.py
@@ -14,7 +14,9 @@ __all__ = (
     "EFS",
     "DataclassInstance",
     "NO_DEFAULT",
+    "TDataclass",
 )
+
 
 PathLike: tp.TypeAlias = str | bytes | Path | os.PathLike
 PathOrHandle: tp.TypeAlias = PathLike | io.IOBase
@@ -39,9 +41,6 @@ class DataclassInstance(tp.Protocol):
     __dataclass_fields__: tp.ClassVar[dict[str, dcs.Field]]
 
 
-class _NO_DEFAULT_TYPE:
-    pass
+TDataclass = tp.TypeVar("TDataclass", bound=DataclassInstance)
 
-
-# Sentinel for no default value. Use a class for a better repr.
-NO_DEFAULT = _NO_DEFAULT_TYPE()
+NO_DEFAULT = tp.Sentinel("NO_DEFAULT")

--- a/tests/test_recursion.py
+++ b/tests/test_recursion.py
@@ -1,0 +1,30 @@
+import dataclasses as dcs
+
+from dataclassio import functional as diof
+
+
+@dcs.dataclass
+class A:
+    a: "A | None" = None
+
+
+@dcs.dataclass
+class B:
+    c: "C | None" = None
+
+
+@dcs.dataclass
+class C:
+    b: B | None = None
+
+
+class TestRecursion:
+    def test_self_references(self):
+        expected = A(a=A(a=A(a=None)))
+        data = {"a": {"a": {"a": None}}}
+        assert diof.from_dict(A, data) == expected
+
+    def test_cyclic_references(self):
+        expected = C(b=B(c=C(b=B())))
+        data = {"b": {"c": {"b": {"c": None}}}}
+        assert diof.from_dict(C, data) == expected

--- a/tests/test_unions.py
+++ b/tests/test_unions.py
@@ -10,21 +10,21 @@ from dataclassio.config import FieldOpts
 @dcs.dataclass
 class HumanAnnotator:
     id: str
-    type: tp.Literal["human_annotator", "human"] = "human_annotator"
+    type: tp.Literal["human_annotator", "human"]
     team: str | None = None
 
 
 @dcs.dataclass
 class MachineAnnotator:
     id: str
-    type: tp.Literal["machine_annotator"] = "machine_annotator"
+    type: tp.Literal["machine_annotator"]
     algorithm_type: str | None = None
 
 
 @dcs.dataclass
 class AdminAnnotator:
     id: str
-    type: tp.Literal["admin_annotator"] = "admin_annotator"
+    type: tp.Literal["admin_annotator"]
     level: int = 1
 
 
@@ -100,8 +100,8 @@ class TestDiscriminatedUnions:
         """Ensure to_dict produces a dictionary that can be re-parsed into the same union."""
         original = Dataset(
             annotators=[
-                HumanAnnotator(id="H1", team="A-Team"),
-                MachineAnnotator(id="M1", algorithm_type="YOLO"),
+                HumanAnnotator(id="H1", team="A-Team", type="human_annotator"),
+                MachineAnnotator(id="M1", algorithm_type="YOLO", type="machine_annotator"),
             ]
         )
 


### PR DESCRIPTION
This MR reworks the parsing logic to support self-referential dataclasses (e.g., nodes in a graph) or dataclasses which form a reference cycle. This is accomplished by sharing a global namespace dict for all the parsing methods which are generated in a single tree and adding anti-recursion checks. The effect is that parsing methods for child fields need not be fully defined for compilation to succeed. The main drawback (I think) is that parsing lists of discriminated unions is probably slower, but I still need to measure that.

Along the way, I also did some reorganization and added more convenience methods.

Closes #16.