### PR TITLE
Specialize IOMixin.to_dict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ nosetests.xml
 coverage.xml
 *.cover
 *.py.cover
+*.lcov
 .hypothesis/
 .pytest_cache/
 cover/
@@ -122,13 +123,14 @@ ipython_config.py
 # pixi.lock
 #   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
 #   in the .venv directory. It is recommended not to include this directory in version control.
-.pixi
+.pixi/*
+!.pixi/config.toml
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/
 
 # Celery stuff
-celerybeat-schedule
+celerybeat-schedule*
 celerybeat.pid
 
 # Redis
@@ -200,6 +202,8 @@ cython_debug/
 #   and can be added to the global gitignore or merged into this file. However, if you prefer,
 #   you could uncomment the following to ignore the entire vscode folder
 # .vscode/
+# Temporary file for partial code execution
+tempCodeRunnerFile.py
 
 # Ruff stuff:
 .ruff_cache/
@@ -214,3 +218,36 @@ __marimo__/
 
 # Streamlit
 .streamlit/secrets.toml
+
+## Visual Studio Code
+# https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+!*.code-workspace
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+## Linux
+# https://github.com/github/gitignore/blob/main/Global/Linux.gitignore
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# Metadata left by Dolphin file manager, which comes with KDE Plasma
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+# Log files created by default by the nohup command
+nohup.out

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,10 +5,11 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Python Debugger: Module",
+            "name": "Pytest",
             "type": "debugpy",
             "request": "launch",
-            "module": "pytest"
+            "module": "pytest",
+            // "cwd": "${workspaceFolder}"
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,9 @@
         "tests"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "terminal.integrated.cwd": "${workspaceFolder}",
+    "terminal.integrated.env.linux": {
+        "PRE_NAMESPACE_PWD": "${cwd}"
+    }
 }

--- a/src/dataclassio/_example_schemas.py
+++ b/src/dataclassio/_example_schemas.py
@@ -567,6 +567,7 @@ class ImputedMetric(IOMixin):
 
     def __post_init__(self, unit, value):
         self.metric = Metric(value, unit)
+        super().__post_init__()
 
 
 @dataclass
@@ -577,6 +578,7 @@ class InitFalseDC(IOMixin):
 
     def __post_init__(self):
         self.c = self.a + self.b
+        super().__post_init__()
 
 
 class Role(enum.Enum):

--- a/src/dataclassio/core/lines.py
+++ b/src/dataclassio/core/lines.py
@@ -5,13 +5,16 @@ import typing_extensions as tp
 __all__ = ("TextLines",)
 
 
-class TextLines:
+class TextLines(tp.Sequence[str]):
     """Object to manage (possibly) indented strings."""
 
-    def __init__(self, *, spacer: str = "  "):
+    def __init__(self, initial: tp.Iterable[str] | None = None, *, spacer: str = "  "):
         self._lines: list[str] = []
         self._spacer = spacer
         self._indent_level = 0
+
+        if initial is not None:
+            self.extend(initial)
 
     def append(self, line: str, /):
         self._lines.append(f"{self._spacer * self._indent_level}{line}")
@@ -46,8 +49,21 @@ class TextLines:
     def __repr__(self):
         return f"<TextLines with {len(self)} lines of text>"
 
+    def __bool__(self):
+        return bool(self._lines)
+
+    # tp.Sequence
+
     def __len__(self):
         return len(self._lines)
 
-    def __bool__(self):
-        return bool(self._lines)
+    def __getitem__(self, key):
+        ret = self._lines[key]
+        if isinstance(ret, list):
+            tl = TextLines(ret, spacer=self._spacer)
+            tl._indent_level = self._indent_level
+            return tl
+        return ret
+
+    def __iter__(self) -> tp.Iterator[str]:
+        return iter(self._lines)

--- a/src/dataclassio/functional/from_dict.py
+++ b/src/dataclassio/functional/from_dict.py
@@ -65,7 +65,7 @@ def make_from_dict_source_code(
         _ns = {}
 
     cls_factory_name = set_variable_in_ns("cls", cls, ns=_ns)
-    current_variable_names: set[str] = {"dikt", "_exc"}
+    current_variable_names: set[str] = {"dikt", "_exc"}  # reserved locals
 
     fields = get_fields(cls, include_all=True)
     field_data: dict[str, FieldSpec] = {}

--- a/src/dataclassio/functional/to_dict.py
+++ b/src/dataclassio/functional/to_dict.py
@@ -32,6 +32,8 @@ def make_to_dict_source_code(
     _field_options: _TotalDioOptions | DioOptions | None = None,
     _ns: dict | None = None,
 ) -> TextLines:
+    from dataclassio.io_mixin import IOMixin
+
     funcname = funcname or f"serialize_{cls.__name__}"
     if _ns is None:
         _ns = {}
@@ -101,25 +103,44 @@ def make_to_dict_source_code(
     #  the bottom of the literals. If we do check some fields for their default value,
     #  we include the extra field population right before export to try keeping the "real"
     #  fields in order in the resulting dictionary.
+    if issubclass(cls, IOMixin):
+        # Subclasses of IOMixin _always_ define an _EXTRA_FIELD_ATTR_NAME,
+        #  so we don't need to use the get attr with a string literal.
+        extras_expr = f"inst.{_EXTRA_FIELD_ATTR_NAME!s}"
+        has_extras_attr = True
+    else:
+        # Otherwise, the object may not define the attribute, so use
+        extras_expr = f"getattr(inst, {_EXTRA_FIELD_ATTR_NAME!r}, {{}})"
+        has_extras_attr = False
 
     if not default_check_lines:
-        literal_lines.append(f"**getattr(inst, {_EXTRA_FIELD_ATTR_NAME!r}, {{}}),")
+        # If there are no default value checks, we can bake this directly into the dict literal
+        literal_lines.append(f"**{extras_expr},")
+    elif has_extras_attr:
+        # Need to call `dikt.update`. We have an extras_attr.
+        default_check_lines.append(f"dikt.update({extras_expr})")
     else:
-        with default_check_lines.indent(f"if hasattr(inst, {_EXTRA_FIELD_ATTR_NAME!r}):"):
-            default_check_lines.append(f"dikt.update(inst.{_EXTRA_FIELD_ATTR_NAME})")
+        # Need to call `dikt.update`. We may or may not have an extras_attr.
+        #  It is faster to use getattr(..., None)
+        default_check_lines.append(f"_extras = {extras_expr.format('None')}")
+        with default_check_lines.indent("if _extras is not None:"):
+            default_check_lines.append("dikt.update(_extras)")
 
     lines = TextLines(spacer=_SPACER)
     with lines.indent(f"def {funcname}(inst):"):
         lines.append(f'"""Serialize a {cls.__name__} instance into a dictionary."""')
-        if literal_lines:
+
+        if default_check_lines:
             with lines.indent("dikt = {"):
                 lines.extend(literal_lines)
             lines.append("}")
+            lines.extend(default_check_lines)
+            lines.append("return dikt")
         else:
-            lines.append("dikt = {}")
-        lines.extend(default_check_lines)
-        lines.append("return dikt")
-
+            # all inline.
+            with lines.indent("return {"):
+                lines.extend(literal_lines)
+            lines.append("}")
     return lines
 
 

--- a/src/dataclassio/io_mixin.py
+++ b/src/dataclassio/io_mixin.py
@@ -25,6 +25,9 @@ def _fname_or_fpointer(handle: PathOrHandle, mode="r", **kw):
 class IOMixin:
     __slots__ = _EXTRA_FIELD_ATTR_NAME
 
+    def __post_init__(self):
+        setattr(self, _EXTRA_FIELD_ATTR_NAME, {})
+
     @property
     def extra_fields(self):
         """Shallow copy of the extra fields stored in this instance from deserialization."""


### PR DESCRIPTION
For subclasses of `IOMixin`, we know at "compile" time that its instances will have an `_extra_fields` instance. This means we can hardcode the `inst._extra_fields` accessor in `to_dict`. Should be a marginal speed improvement for this common use case.