### PR TITLE
Add hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # DataclassIO
 
-`DataclassIO` is a *fast* package for rountrip conversion between python literals and dataclass hierarchies.
+`DataclassIO` is a package for *fast*  roundtrip conversion between python literals and dataclass hierarchies.
 
-This project is in its early stages, but it is has minimum viable functionality for my use-cases.
+This project is in its early stages. If you need maturity and _lots_ of bells of whistles, consider another library :)
 
 ## Supported Types and Constructs
 
@@ -24,9 +24,11 @@ The library also supports common dataclass features:
 
 - Default values and default factories: `field(default=..., default_factory=...)`
 - Init-only and `init=False` fields
-  - Note that `init=False` fields are still exported as usual.
+  - Note that `init=False` fields are still exported.
 - `kw_only` fields and dataclasses.
 - Class variables.
+
+The library also supports a handful of hooks that can be used to customize the serialization or deserialization process, or run other side effects during `to_dict` and `from_dict` calls.
 
 ## Example
 
@@ -36,7 +38,7 @@ from dataclasses import dataclass, field
 from dataclassio import IOMixin, EFS
 
 @dataclass
-class Address(IOMixin):
+class Address:
     city: str
     zip_code: tp.Optional[str] = None
 
@@ -46,7 +48,7 @@ class User(IOMixin):
     id: int
     name: str
     is_admin: bool = False
-    address: tp.Optional[Address] = None  # <-- Address need not derive from IOMixin!
+    address: tp.Optional[Address] = None  # <-- Address does not derive from IOMixin!
     named_addresses: dict[str, Address] = field(default_factory=dict)
 
 ## Dictionary -> Dataclass
@@ -62,7 +64,7 @@ assert isinstance(actual.named_addresses["home"], Address)
 assert actual.named_addresses["work"].city == "Coolsville"
 
 ## Dataclass -> Dictionary (note that the default-valued-fields are excluded)
-dikt = actual.to_dict(skip_if_default=True)
+dikt = actual.to_dict(skip_defaults=True)
 assert dikt == data
 
 ## Extra Fields are captured:
@@ -77,12 +79,15 @@ assert address_obj.to_dict() == address_data  # extra fields survive round trip.
 
 ## Configuration
 
-A handful of configuration options are supported to customize serialization and deserialization. These can be provided either at time of a `to_dict` or `from_dict` call ("call-level config") or can be applied to individual dataclass fields statically ("field-level config"). The following options are supported:
+A handful of configuration options are supported to customize serialization and deserialization. These can be provided either at time of a `to_dict` or `from_dict` call ("call-level config") or can be applied to individual dataclass fields statically ("field-level config"). Not all options can be provided in both places. The following options are supported:
 
 * `discriminator`: The name of a field to use when discrimating between unions of dataclass types.
-* `skip_if_default`: A flag to omit fields during the `to_dict` call if they have the default value.
+* `skip_if_default`/`skip_defaults`: Flags to omit fields during the `to_dict` call if they have the default value. `skip_if_default` is field-level only, and has the highest precedence. `skip_defaults` can be applied at the call- and field-level. At the field-level, `skip_defaults` has a slightly different meaning from `skip_if_default`:
+    * `x: T = field(..., FieldOptions(skip_if_default=True))`: Suppress serialization of the field `x` if its value equals the default.
+    * `x: T = field(..., FieldOptions(skip_defaults=True))`: Suppress serialization of `T`'s fields if they have a default value.
 * `extra_field_strategy`: The preferred method for handling unexpected fields during deserialization (`from_dict`). By default they are ignored. Alternatively, an exception can be raised (`STRICT`-mode) or they can be captured into a private attribute of the object (`CAPTURE`-mode). In `CAPTURE`-mode, the unexpected fields are yielded in the `to_dict` call, supporting full round-tripping.
 * `include_src_in_docstring`: A flag to include `to_dict` and `from_dict` method source code in their corresponding docstrings. This is useful since their source code is dynamically generated.
+* `skip_hooks`: A flag to skip `to_dict` and `from_dict` hooks, even if they are defined on a type.
 
 ### Propagation and Precedence
 
@@ -90,7 +95,7 @@ When a configuration option is specified at both the call- and field-level, the 
 
 In addition to precedence differences, options propagate differently depending on where they are defined. Call-level config options always propagate through fields which are themselves dataclass-typed. Field-level config options do not.
 
-Field-level options can be conceptually divided into "shallow" and "deep" categories. "Shallow" options (e.g., `discriminator`) affect the code-generation for their contained dataclass but not the nested dataclass. Meanwhile, "deep" options (e.g., `extra_field_strategy`) are the inverse - they _do not_ affect the code-generation for their contained dataclass but _do_ for the affected field. Most of the time, this distinction is natural and does not need to be top of mind.
+Field-level options can be divided into "local" and "deep once" propagation categories. "Local" options (e.g., `discriminator`) affect the code-generation for their contained dataclass but not the nested dataclass. Meanwhile, "deep once" options (e.g., `extra_field_strategy`) are the inverse - they _do not_ affect the code-generation for their contained dataclass but _do_ for the affected field. Most of the time, this distinction is the natural interpretation and does not need to be top of mind.
 
 ## Benchmarks
 

--- a/src/dataclassio/config2.py
+++ b/src/dataclassio/config2.py
@@ -4,7 +4,7 @@ from enum import Enum, auto
 
 import typing_extensions as tp
 
-from .sentinels import NO_VALUE, NoValueOr
+from .constants import NO_VALUE, NoValueOr
 from .types import EFS
 
 __all__ = (
@@ -107,12 +107,26 @@ INCLUDE_SRC_IN_DOCSTRING = OptionSpec(
     to_str=lambda _: "incl_src",
 )
 
+SKIP_HOOKS = OptionSpec(
+    name="skip_hooks",
+    type_str="bool",
+    default=False,
+    scopes={
+        S.CALL: P.DEEP,
+        S.TYPE: P.LOCAL,
+        S.FIELD: P.DEEP_ONCE,
+    },
+    to_str=lambda _: "skip_hooks",
+)
+
+
 ALL_OPTIONS: tuple[OptionSpec, ...] = (
     EXTRA_FIELD_STRATEGY,
     DISCRIMINATOR,
     SKIP_IF_DEFAULT,
     SKIP_DEFAULTS,
     INCLUDE_SRC_IN_DOCSTRING,
+    SKIP_HOOKS,
 )
 
 REGISTRY: dict[str, OptionSpec] = {o.name: o for o in ALL_OPTIONS}
@@ -128,11 +142,13 @@ class CallOptions(tp.TypedDict, total=False):
     extra_field_strategy: EFS
     skip_defaults: NoValueOr[bool]
     include_src_in_docstring: bool
+    skip_hooks: bool
 
 
 class TypeOptions(tp.TypedDict, total=False):
     extra_field_strategy: EFS
     skip_defaults: NoValueOr[bool]
+    skip_hooks: bool
 
 
 class _FieldOptions(tp.TypedDict, total=False):
@@ -140,6 +156,7 @@ class _FieldOptions(tp.TypedDict, total=False):
     discriminator: NoValueOr[str]
     skip_if_default: NoValueOr[bool]
     skip_defaults: NoValueOr[bool]
+    skip_hooks: bool
 
 
 class DioOptions(tp.TypedDict, total=True):
@@ -148,6 +165,7 @@ class DioOptions(tp.TypedDict, total=True):
     skip_if_default: NoValueOr[bool]
     skip_defaults: NoValueOr[bool]
     include_src_in_docstring: bool
+    skip_hooks: bool
 
 
 def FieldOptions(**kw: tp.Unpack[_FieldOptions]):
@@ -252,6 +270,7 @@ class ResolvedConfig:
             skip_defaults=self["skip_defaults"],
             skip_if_default=self["skip_if_default"],
             include_src_in_docstring=self["include_src_in_docstring"],
+            skip_hooks=self["skip_hooks"],
         )
 
     def cache_key(self):

--- a/src/dataclassio/constants.py
+++ b/src/dataclassio/constants.py
@@ -2,6 +2,32 @@ from enum import Enum, auto
 
 import typing_extensions as tp
 
+__all__ = (
+    "_EXTRA_FIELD_ATTR_NAME",
+    "_SPACER",
+    "NO_DEFAULT",
+    "NoDefaultOr",
+    "NO_VALUE",
+    "NoValueOr",
+    "IN_PROGRESS",
+    "InProgressOr",
+    "CYCLE_DETECTED",
+    "CycleOr",
+    "_PRE_TO_DICT_HOOK",
+    "_POST_TO_DICT_HOOK",
+    "_PRE_FROM_DICT_HOOK",
+    "_POST_FROM_DICT_HOOK",
+)
+
+
+_EXTRA_FIELD_ATTR_NAME = "_extra_fields"
+_SPACER = "  "
+
+_PRE_TO_DICT_HOOK = "__pre_to_dict__"
+_POST_TO_DICT_HOOK = "__post_to_dict__"
+_PRE_FROM_DICT_HOOK = "__pre_from_dict__"
+_POST_FROM_DICT_HOOK = "__post_from_dict__"
+
 
 class _Sentinels(Enum):
     NO_DEFAULT = auto()

--- a/src/dataclassio/core/_shared_codegen.py
+++ b/src/dataclassio/core/_shared_codegen.py
@@ -3,7 +3,7 @@ import linecache
 import typing_extensions as tp
 
 from dataclassio.config2 import ResolvedConfig
-from dataclassio.sentinels import CYCLE_DETECTED, IN_PROGRESS, CycleOr
+from dataclassio.constants import CYCLE_DETECTED, IN_PROGRESS, CycleOr
 from dataclassio.types import DataclassInstance, SourceCodeMaker, TNamespace
 
 from .field_methods import get_fields
@@ -85,3 +85,28 @@ def validate_type_hints(kls: type[DataclassInstance]):
         resolved_annotations = tp.get_annotations(kls, eval_str=True, format=tp.Format.VALUE)
         for f in forward_ref_fields:
             f.type = resolved_annotations[f.name]
+
+
+def is_overridden(child_cls: type, base_cls: type, name: str) -> bool:
+    child_attr = getattr(child_cls, name, None)
+    base_attr = getattr(base_cls, name, None)
+
+    if child_attr is None or base_attr is None:
+        return False
+
+    # 2. Extract the underlying function for classmethods/staticmethods
+    # Bound methods (like classmethods) have a __func__ attribute.
+    # Regular methods in Python 3 are just functions when accessed via the class.
+    child_func = getattr(child_attr, "__func__", child_attr)
+    base_func = getattr(base_attr, "__func__", base_attr)
+
+    return child_func is not base_func
+
+
+def overrides_hook(child_cls: type, name: str) -> bool:
+    from dataclassio import IOMixin
+
+    if issubclass(child_cls, IOMixin):
+        return is_overridden(child_cls, IOMixin, name)
+
+    return callable(getattr(child_cls, name, None))

--- a/src/dataclassio/core/expression_builder.py
+++ b/src/dataclassio/core/expression_builder.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import typing_extensions as tp
 
 from dataclassio.config2 import DioOptions
-from dataclassio.sentinels import CYCLE_DETECTED, NO_VALUE, CycleOr, NoValueOr
+from dataclassio.constants import CYCLE_DETECTED, NO_VALUE, CycleOr, NoValueOr
 from dataclassio.types import DataclassInstance, FunctionMaker
 
 from .field_methods import get_fields

--- a/src/dataclassio/core/field_methods.py
+++ b/src/dataclassio/core/field_methods.py
@@ -2,7 +2,7 @@ import dataclasses as dcs
 
 import typing_extensions as tp
 
-from dataclassio.sentinels import NO_DEFAULT, NoDefaultOr
+from dataclassio.constants import NO_DEFAULT, NoDefaultOr
 from dataclassio.types import TNamespace
 
 from .variables import set_variable_in_ns

--- a/src/dataclassio/core/from_dict.py
+++ b/src/dataclassio/core/from_dict.py
@@ -5,10 +5,16 @@ from functools import partial
 import typing_extensions as tp
 
 from dataclassio.config2 import ResolvedConfig
-from dataclassio.sentinels import CycleOr
+from dataclassio.constants import (
+    _EXTRA_FIELD_ATTR_NAME,
+    _POST_FROM_DICT_HOOK,
+    _PRE_FROM_DICT_HOOK,
+    _SPACER,
+    CycleOr,
+)
 from dataclassio.types import EFS, DataclassInstance, TDataclass, TNamespace
 
-from ._shared_codegen import maker_core
+from ._shared_codegen import maker_core, overrides_hook
 from .expression_builder import SerializerData, get_field_expression
 from .field_methods import field_has_default, get_fields, parse_default_expression
 from .lines import TextLines
@@ -20,8 +26,6 @@ __all__ = (
 )
 
 _KNOWN_DESERIALIZERS: dict[tuple[type, tp.Any], tp.Callable[[tp.Mapping], tp.Any]] = {}
-_EXTRA_FIELD_ATTR_NAME = "_extra_fields"
-_SPACER = "  "
 
 
 class FieldSpec(tp.NamedTuple):
@@ -46,6 +50,7 @@ def make_from_dict_source_code(
     _ns: TNamespace | None = None,
 ) -> TextLines:
     """Generate the source code and necessary namespace for a from_dict deserialization method."""
+
     if _ns is None:
         _ns = {}
 
@@ -97,8 +102,11 @@ def make_from_dict_source_code(
     # Assemble the final function body
     # Start with the try/except block for required keys.
     body = TextLines(spacer=_SPACER)
-    req_fields = [v for v in field_data.values() if not v.has_default]
 
+    if overrides_hook(cls, _PRE_FROM_DICT_HOOK) and not frame_config["skip_hooks"]:
+        body.append(f"dikt = {cls_factory_name}.{_PRE_FROM_DICT_HOOK}(dikt)")
+
+    req_fields = [v for v in field_data.values() if not v.has_default]
     if req_fields:
         with body.indent("try:"):
             for fs in req_fields:
@@ -145,14 +153,15 @@ def make_from_dict_source_code(
         attribute_name=_EXTRA_FIELD_ATTR_NAME,
     )
 
-    if extras:
-        # We have extras, so save the inst
-        body.append(f"inst = {cls_factory_name}({data_str})")
-        # N.B. For EFS.STRICT, this _could_ go at the top of the function body to bail early
-        body.extend(extras)
-        body.append("return inst")
-    else:
-        body.append(f"return {cls_factory_name}({data_str})")
+    # We have extras, so save the inst
+    body.append(f"inst = {cls_factory_name}({data_str})")
+    # N.B. For EFS.STRICT, this _could_ go at the top of the function body to bail early
+    body.extend(extras)
+
+    if overrides_hook(cls, _POST_FROM_DICT_HOOK) and not frame_config["skip_hooks"]:
+        body.append(f"inst.{_POST_FROM_DICT_HOOK}(dikt)")
+
+    body.append("return inst")
 
     # Pack it all up!
     funcname = frame_config.get_func_name(cls, "deserialize")

--- a/src/dataclassio/core/to_dict.py
+++ b/src/dataclassio/core/to_dict.py
@@ -3,17 +3,22 @@ from functools import partial
 import typing_extensions as tp
 
 from dataclassio.config2 import ResolvedConfig
-from dataclassio.sentinels import NO_VALUE, CycleOr
+from dataclassio.constants import (
+    _EXTRA_FIELD_ATTR_NAME,
+    _POST_TO_DICT_HOOK,
+    _PRE_TO_DICT_HOOK,
+    _SPACER,
+    NO_VALUE,
+    CycleOr,
+)
 from dataclassio.types import DataclassInstance, TDataclass, TNamespace
 
-from ._shared_codegen import maker_core
+from ._shared_codegen import maker_core, overrides_hook
 from .expression_builder import SerializerData, get_field_expression
 from .field_methods import field_has_default, get_fields, parse_default_expression
-from .from_dict import _EXTRA_FIELD_ATTR_NAME
 from .lines import TextLines
 
 _KNOWN_SERIALIZERS: dict[tuple[type, tp.Hashable], tp.Callable[[DataclassInstance], dict]] = {}
-_SPACER = "  "
 
 
 def make_to_dict_source_code(
@@ -111,20 +116,26 @@ def make_to_dict_source_code(
 
     lines = TextLines(spacer=_SPACER)
     funcname = frame_config.get_func_name(cls, "serialize")
+
+    if frame_config["skip_hooks"]:
+        insert_pre = False
+        insert_post = False
+    else:
+        insert_pre = overrides_hook(cls, _PRE_TO_DICT_HOOK)
+        insert_post = overrides_hook(cls, _POST_TO_DICT_HOOK)
+
     with lines.indent(f"def {funcname}(inst):"):
         lines.append(f'"""Serialize a {cls.__name__} instance into a dictionary."""')
+        if insert_pre:
+            lines.append(f"inst.{_PRE_TO_DICT_HOOK}()")
 
-        if default_check_lines:
-            with lines.indent("dikt = {"):
-                lines.extend(literal_lines)
-            lines.append("}")
-            lines.extend(default_check_lines)
-            lines.append("return dikt")
-        else:
-            # all inline.
-            with lines.indent("return {"):
-                lines.extend(literal_lines)
-            lines.append("}")
+        with lines.indent("dikt = {"):
+            lines.extend(literal_lines)
+        lines.append("}")
+        lines.extend(default_check_lines)
+        if insert_post:
+            lines.append(f"dikt = inst.{_POST_TO_DICT_HOOK}(dikt)")
+        lines.append("return dikt")
     return lines
 
 

--- a/src/dataclassio/core/variables.py
+++ b/src/dataclassio/core/variables.py
@@ -2,7 +2,7 @@ import uuid
 
 import typing_extensions as tp
 
-from dataclassio.sentinels import NO_VALUE, NoValueOr
+from dataclassio.constants import NO_VALUE, NoValueOr
 from dataclassio.types import TNamespace
 
 __all__ = (

--- a/src/dataclassio/functional.py
+++ b/src/dataclassio/functional.py
@@ -3,9 +3,9 @@
 import typing_extensions as tp
 
 from .config2 import CallOptions, ResolvedConfig
+from .constants import CYCLE_DETECTED
 from .core import from_dict as load_core
 from .core import to_dict as dump_core
-from .sentinels import CYCLE_DETECTED
 from .types import DataclassInstance, TDataclass
 
 __all__ = (

--- a/src/dataclassio/io_mixin.py
+++ b/src/dataclassio/io_mixin.py
@@ -8,7 +8,7 @@ import typing_extensions as tp
 
 from . import functional as diof
 from .config2 import CallOptions
-from .core.from_dict import _EXTRA_FIELD_ATTR_NAME
+from .constants import _EXTRA_FIELD_ATTR_NAME
 from .types import PathOrHandle
 
 
@@ -35,6 +35,8 @@ class IOMixin:
         if hasattr(self, _EXTRA_FIELD_ATTR_NAME):
             return dict(getattr(self, _EXTRA_FIELD_ATTR_NAME))
         return {}
+
+    # IO methods
 
     @classmethod
     def from_json_file(
@@ -103,3 +105,17 @@ class IOMixin:
         dump_kw = dump_kw or {}
         with _fname_or_fpointer(fname_or_handle, mode="w", encoding="utf-8") as fp:
             json.dump(obj, fp, **dump_kw)
+
+    # Hooks
+    def __pre_to_dict__(self) -> None:
+        return
+
+    def __post_to_dict__(self, dikt: dict) -> dict:
+        return dikt
+
+    @classmethod
+    def __pre_from_dict__(cls, dikt: dict) -> dict:
+        return dikt
+
+    def __post_from_dict__(self, dikt: dict) -> None:
+        return

--- a/src/dataclassio/io_mixin.py
+++ b/src/dataclassio/io_mixin.py
@@ -108,14 +108,60 @@ class IOMixin:
 
     # Hooks
     def __pre_to_dict__(self) -> None:
+        """Hook invoked before serialization to a dictionary.
+
+        Called on the instance prior to any field being read for ``to_dict``.
+        Use this to normalize, validate, or otherwise mutate ``self`` in place
+        so that the serialized output reflects the adjustments. To prevent serialization,
+        raise any exception.
+
+        The return value is ignored; this hook exists purely for its side effects on ``self``.
+        """
         return
 
     def __post_to_dict__(self, dikt: dict) -> dict:
+        """Hook invoked after serialization to a dict.
+
+        Called with the produced dictionary representation of ``self`` as its only argument.
+        This hook should return the desired dictionary to be returned from ``to_dict``, and that
+        may be the input argument. You may mute the input dictionary or return a new/replacement
+        dictionary to be used.
+
+        Args:
+            dikt: The dict produced by the generated ``to_dict`` method.
+
+        Returns:
+            The dictionary to return from ``to_dict``.
+        """
         return dikt
 
     @classmethod
     def __pre_from_dict__(cls, dikt: dict) -> dict:
+        """Hook invoked before deserialization from a dict.
+
+        Called with the raw input dict before any field is read for
+        ``from_dict``. You may mutate ``dikt``,
+        or return a new/replacement dict to be used as the source for
+        deserialization. Useful for migrating legacy objects, renaming keys,
+        or filling in defaults.
+
+        Args:
+            dikt: The input dict passed to ``from_dict``.
+
+        Returns:
+            The dict to deserialize from.
+        """
         return dikt
 
     def __post_from_dict__(self, dikt: dict) -> None:
+        """Hook invoked after deserialization from a dict.
+
+        Called on the newly constructed instance after all fields have been
+        populated from ``dikt``. Use this to perform validation, derive
+        computed attributes, or otherwise finalize ``self`` in place.
+
+        Args:
+            dikt: The dict that was used to construct ``self`` (including any processing from
+                ``__pre_from_dict``, if implemented).
+        """
         return

--- a/src/dataclassio/types.py
+++ b/src/dataclassio/types.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import typing_extensions as tp
 
-from dataclassio.sentinels import CycleOr
+from dataclassio.constants import CycleOr
 
 if tp.TYPE_CHECKING:
     from dataclassio.config2 import ResolvedConfig

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 
-from dataclassio import IOMixin  # adjust import
+import pytest
+
+from dataclassio import IOMixin
 from dataclassio import functional as F
 
 
@@ -14,12 +16,6 @@ class Point(IOMixin):
 # __pre_to_dict__
 # ---------------------------------------------------------------------------
 class TestPreToDict:
-    def test_not_invoked_when_not_overridden(self):
-        # Sanity check: base implementation is a no-op, and codegen should
-        # not even emit a call to it. We can't observe "not called" directly,
-        # but we can at least confirm to_dict works without surprises.
-        assert Point(1, 2).to_dict() == {"x": 1, "y": 2}
-
     def test_invoked_when_overridden(self):
         calls = []
 
@@ -70,7 +66,7 @@ class TestPostToDict:
         class Tagged(Point):
             def __post_to_dict__(self, dikt):
                 dikt["tag"] = "ok"
-                # implicit None return
+                return dikt
 
         assert Tagged(1, 2).to_dict() == {"x": 1, "y": 2, "tag": "ok"}
 
@@ -107,7 +103,7 @@ class TestPreFromDict:
             def __pre_from_dict__(cls, dikt):
                 if "X" in dikt:
                     dikt["x"] = dikt.pop("X")
-                # implicit None return
+                return dikt
 
         assert Migrating.from_dict({"X": 1, "y": 2}) == Migrating(1, 2)
 
@@ -218,6 +214,7 @@ class TestDuckTypedHooks:
 
             def __post_to_dict__(self, dikt):
                 dikt["tag"] = "ok"
+                return dikt
 
         assert F.to_dict(P(1, 2)) == {"x": 1, "y": 2, "tag": "ok"}
 
@@ -245,3 +242,63 @@ class TestDuckTypedHooks:
                 self.x *= -1
 
         assert F.from_dict(P, {"x": 1, "y": 2}) == P(-1, 2)
+
+
+# ---------------------------------------------------------------------------
+# Skip hooks
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Hooked(IOMixin):
+    x: int
+    y: int
+
+    def __post_init__(self):
+        self.calls = []
+        super().__post_init__()
+
+    def __pre_to_dict__(self) -> None:
+        self.calls.append("pre_to_dict")
+
+    def __post_to_dict__(self, dikt: dict) -> dict:
+        dikt["post_to_dict"] = True
+        return dikt
+
+    @classmethod
+    def __pre_from_dict__(cls, dikt: dict) -> dict:
+        dikt = dict(dikt)
+        dikt.setdefault("x", 0)
+        dikt["_pre_from_dict"] = True  # Will be ignored.
+        return dikt
+
+    def __post_from_dict__(self, dikt: dict) -> None:
+        self.calls.append("post_from_dict")
+
+
+class TestCallLevelSkipHooks:
+    def test_to_dict_runs_hooks_by_default(self):
+        h = Hooked(1, 2)
+        d = h.to_dict()
+
+        assert "pre_to_dict" in h.calls
+        assert d.get("post_to_dict") is True
+
+    def test_to_dict_skips_hooks_when_requested(self):
+        h = Hooked(1, 2)
+        d = h.to_dict(skip_hooks=True)
+        assert h.calls == []
+        assert "post_to_dict" not in d
+
+    def test_from_dict_runs_hooks_by_default(self):
+        h = Hooked.from_dict({"x": 1, "y": 2})
+        assert "post_from_dict" in h.calls
+
+    def test_from_dict_skips_hooks_when_requested(self):
+        # __pre_from_dict__ would inject a default for x; skipping should
+        # mean the missing key causes the usual error path.
+        with pytest.raises(KeyError):
+            Hooked.from_dict({"y": 2}, skip_hooks=True)
+
+        h = Hooked.from_dict({"x": 1, "y": 2}, skip_hooks=True)
+        assert h.calls == []

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,247 @@
+from dataclasses import dataclass
+
+from dataclassio import IOMixin  # adjust import
+from dataclassio import functional as F
+
+
+@dataclass
+class Point(IOMixin):
+    x: int
+    y: int
+
+
+# ---------------------------------------------------------------------------
+# __pre_to_dict__
+# ---------------------------------------------------------------------------
+class TestPreToDict:
+    def test_not_invoked_when_not_overridden(self):
+        # Sanity check: base implementation is a no-op, and codegen should
+        # not even emit a call to it. We can't observe "not called" directly,
+        # but we can at least confirm to_dict works without surprises.
+        assert Point(1, 2).to_dict() == {"x": 1, "y": 2}
+
+    def test_invoked_when_overridden(self):
+        calls = []
+
+        @dataclass
+        class Tracked(Point):
+            def __pre_to_dict__(self):
+                calls.append(self)
+
+        t = Tracked(1, 2)
+        t.to_dict()
+        assert calls == [t]
+
+    def test_can_mutate_self_before_serialization(self):
+        @dataclass
+        class Shifted(Point):
+            def __pre_to_dict__(self):
+                self.x += 100
+
+        assert Shifted(1, 2).to_dict() == {"x": 101, "y": 2}
+
+    def test_return_value_is_ignored(self):
+        @dataclass
+        class Bogus(Point):
+            def __pre_to_dict__(self):
+                return {"not": "used"}
+
+        assert Bogus(1, 2).to_dict() == {"x": 1, "y": 2}
+
+
+# ---------------------------------------------------------------------------
+# __post_to_dict__
+# ---------------------------------------------------------------------------
+class TestPostToDict:
+    def test_invoked_with_serialized_dict(self):
+        seen = []
+
+        @dataclass
+        class Tracked(Point):
+            def __post_to_dict__(self, dikt):
+                seen.append(dikt)
+                return dikt
+
+        Tracked(1, 2).to_dict()
+        assert seen == [{"x": 1, "y": 2}]
+
+    def test_can_mutate_dict_in_place(self):
+        @dataclass
+        class Tagged(Point):
+            def __post_to_dict__(self, dikt):
+                dikt["tag"] = "ok"
+                # implicit None return
+
+        assert Tagged(1, 2).to_dict() == {"x": 1, "y": 2, "tag": "ok"}
+
+    def test_can_replace_dict_by_returning_new(self):
+        @dataclass
+        class Replaced(Point):
+            def __post_to_dict__(self, dikt):
+                return {"replaced": True}
+
+        assert Replaced(1, 2).to_dict() == {"replaced": True}
+
+
+# ---------------------------------------------------------------------------
+# __pre_from_dict__
+# ---------------------------------------------------------------------------
+class TestPreFromDict:
+    def test_invoked_with_input_dict(self):
+        seen = []
+
+        @dataclass
+        class Tracked(Point):
+            @classmethod
+            def __pre_from_dict__(cls, dikt):
+                seen.append((cls, dict(dikt)))
+                return dikt
+
+        Tracked.from_dict({"x": 1, "y": 2})
+        assert seen == [(Tracked, {"x": 1, "y": 2})]
+
+    def test_can_mutate_dict_in_place(self):
+        @dataclass
+        class Migrating(Point):
+            @classmethod
+            def __pre_from_dict__(cls, dikt):
+                if "X" in dikt:
+                    dikt["x"] = dikt.pop("X")
+                # implicit None return
+
+        assert Migrating.from_dict({"X": 1, "y": 2}) == Migrating(1, 2)
+
+    def test_can_replace_dict_by_returning_new(self):
+        @dataclass
+        class Replacing(Point):
+            @classmethod
+            def __pre_from_dict__(cls, dikt):
+                return {"x": dikt["x"] * 10, "y": dikt["y"] * 10}
+
+        assert Replacing.from_dict({"x": 1, "y": 2}) == Replacing(10, 20)
+
+
+# ---------------------------------------------------------------------------
+# __post_from_dict__
+# ---------------------------------------------------------------------------
+class TestPostFromDict:
+    def test_invoked_on_constructed_instance(self):
+        seen = []
+
+        @dataclass
+        class Tracked(Point):
+            def __post_from_dict__(self, dikt):
+                seen.append((self, dikt))
+
+        p = Tracked.from_dict({"x": 1, "y": 2})
+        assert seen == [(p, {"x": 1, "y": 2})]
+
+    def test_can_mutate_self_after_deserialization(self):
+        @dataclass
+        class Finalized(Point):
+            def __post_from_dict__(self, dikt):
+                self.x *= -1
+
+        assert Finalized.from_dict({"x": 1, "y": 2}) == Finalized(-1, 2)
+
+    def test_return_value_is_ignored(self):
+        @dataclass
+        class Bogus(Point):
+            def __post_from_dict__(self, dikt):
+                return Point(999, 999)
+
+        assert Bogus.from_dict({"x": 1, "y": 2}) == Bogus(1, 2)
+
+
+# ---------------------------------------------------------------------------
+# Hook ordering
+# ---------------------------------------------------------------------------
+class TestHookOrdering:
+    def test_to_dict_calls_pre_then_post(self):
+        calls = []
+
+        @dataclass
+        class Tracked(Point):
+            def __pre_to_dict__(self):
+                calls.append("pre")
+
+            def __post_to_dict__(self, dikt):
+                calls.append("post")
+                return dikt
+
+        Tracked(1, 2).to_dict()
+        assert calls == ["pre", "post"]
+
+    def test_from_dict_calls_pre_then_post(self):
+        calls = []
+
+        @dataclass
+        class Tracked(Point):
+            @classmethod
+            def __pre_from_dict__(cls, dikt):
+                calls.append("pre")
+                return dikt
+
+            def __post_from_dict__(self, dikt):
+                calls.append("post")
+
+        Tracked.from_dict({"x": 1, "y": 2})
+        assert calls == ["pre", "post"]
+
+
+# ---------------------------------------------------------------------------
+# Duck-typed hooks on classes that do NOT inherit from IOMixin
+# ---------------------------------------------------------------------------
+
+
+class TestDuckTypedHooks:
+    def test_pre_to_dict_on_non_mixin_class(self):
+        calls = []
+
+        @dataclass
+        class P:
+            x: int
+            y: int
+
+            def __pre_to_dict__(self):
+                calls.append("pre")
+                self.x += 100
+
+        assert F.to_dict(P(1, 2)) == {"x": 101, "y": 2}
+        assert calls == ["pre"]
+
+    def test_post_to_dict_on_non_mixin_class(self):
+        @dataclass
+        class P:
+            x: int
+            y: int
+
+            def __post_to_dict__(self, dikt):
+                dikt["tag"] = "ok"
+
+        assert F.to_dict(P(1, 2)) == {"x": 1, "y": 2, "tag": "ok"}
+
+    def test_pre_from_dict_on_non_mixin_class(self):
+        @dataclass
+        class P:
+            x: int
+            y: int
+
+            @classmethod
+            def __pre_from_dict__(cls, dikt):
+                if "X" in dikt:
+                    dikt["x"] = dikt.pop("X")
+                return dikt
+
+        assert F.from_dict(P, {"X": 1, "y": 2}) == P(1, 2)
+
+    def test_post_from_dict_on_non_mixin_class(self):
+        @dataclass
+        class P:
+            x: int
+            y: int
+
+            def __post_from_dict__(self, dikt):
+                self.x *= -1
+
+        assert F.from_dict(P, {"x": 1, "y": 2}) == P(-1, 2)


### PR DESCRIPTION
This MR adds support for hooks that run before and after `to_dict` and `from_dict`. The calls to these hooks are implemented with zero-cost overhead. If the type doesn't define hooks, they are not invoked or looked for at runtime. If they are defined on the type, then the call to the hooks is inserted without any extra gating.

The hooks allow for all sorts of current use-cases that aren't currently supported by the codegen, such as type validation, aliasing, and so forth.

Here are the signatures.

```python

# Hooks
    def __pre_to_dict__(self) -> None:
        """Hook invoked before serialization to a dictionary.

        Called on the instance prior to any field being read for ``to_dict``.
        Use this to normalize, validate, or otherwise mutate ``self`` in place
        so that the serialized output reflects the adjustments. To prevent serialization,
        raise any exception.

        The return value is ignored; this hook exists purely for its side effects on ``self``.
        """
        return

    def __post_to_dict__(self, dikt: dict) -> dict:
        """Hook invoked after serialization to a dict.

        Called with the produced dictionary representation of ``self`` as its only argument.
        This hook should return the desired dictionary to be returned from ``to_dict``, and that
        may be the input argument. You may mute the input dictionary or return a new/replacement
        dictionary to be used.

        Args:
            dikt: The dict produced by the generated ``to_dict`` method.

        Returns:
            The dictionary to return from ``to_dict``.
        """
        return dikt

    @classmethod
    def __pre_from_dict__(cls, dikt: dict) -> dict:
        """Hook invoked before deserialization from a dict.

        Called with the raw input dict before any field is read for
        ``from_dict``. You may mutate ``dikt``,
        or return a new/replacement dict to be used as the source for
        deserialization. Useful for migrating legacy objects, renaming keys,
        or filling in defaults.

        Args:
            dikt: The input dict passed to ``from_dict``.

        Returns:
            The dict to deserialize from.
        """
        return dikt

    def __post_from_dict__(self, dikt: dict) -> None:
        """Hook invoked after deserialization from a dict.

        Called on the newly constructed instance after all fields have been
        populated from ``dikt``. Use this to perform validation, derive
        computed attributes, or otherwise finalize ``self`` in place.

        Args:
            dikt: The dict that was used to construct ``self`` (including any processing from
                ``__pre_from_dict``, if implemented).
        """
        return
        
```

Oh, and the hooks work whether you use the `IOMixin` or not!

Closes #18.