### PR TITLE
Add options to skip dumping specific fields (`skip`) and skip dumping extra fields altogether (`skip_extras`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,15 @@ assert address_obj.to_dict() == address_data  # extra fields survive round trip.
 
 A handful of configuration options are supported to customize serialization and deserialization. These can be provided either at time of a `to_dict` or `from_dict` call ("call-level config") or can be applied to individual dataclass fields statically ("field-level config"). Not all options can be provided in both places. The following options are supported:
 
+* `disable_hooks`: A flag to skip `to_dict` and `from_dict` hooks, even if they are defined on a type.
 * `discriminator`: The name of a field to use when discrimating between unions of dataclass types.
+* `extra_field_strategy`: The preferred method for handling unexpected fields during deserialization (`from_dict`). By default they are ignored. Alternatively, an exception can be raised (`STRICT`-mode) or they can be captured into a private attribute of the object (`CAPTURE`-mode). In `CAPTURE`-mode, the unexpected fields are yielded in the `to_dict` call, supporting full round-tripping.
+* `include_src_in_docstring`: A flag to include `to_dict` and `from_dict` method source code in their corresponding docstrings. This is useful since their source code is dynamically generated.
+* `skip`: Field-level flag to omit a field from `to_dict`.
+* `skip_extras`: Call-level flag to omit any cpatured extra fields from `to_dict`. If you know that your instances do not have extras, or don't care to preserve this, this can be safely toggled to `True`.
 * `skip_if_default`/`skip_defaults`: Flags to omit fields during the `to_dict` call if they have the default value. `skip_if_default` is field-level only, and has the highest precedence. `skip_defaults` can be applied at the call- and field-level. At the field-level, `skip_defaults` has a slightly different meaning from `skip_if_default`:
     * `x: T = field(..., FieldOptions(skip_if_default=True))`: Suppress serialization of the field `x` if its value equals the default.
     * `x: T = field(..., FieldOptions(skip_defaults=True))`: Suppress serialization of `T`'s fields if they have a default value.
-* `extra_field_strategy`: The preferred method for handling unexpected fields during deserialization (`from_dict`). By default they are ignored. Alternatively, an exception can be raised (`STRICT`-mode) or they can be captured into a private attribute of the object (`CAPTURE`-mode). In `CAPTURE`-mode, the unexpected fields are yielded in the `to_dict` call, supporting full round-tripping.
-* `include_src_in_docstring`: A flag to include `to_dict` and `from_dict` method source code in their corresponding docstrings. This is useful since their source code is dynamically generated.
-* `skip_hooks`: A flag to skip `to_dict` and `from_dict` hooks, even if they are defined on a type.
 
 ### Propagation and Precedence
 

--- a/src/dataclassio/__init__.py
+++ b/src/dataclassio/__init__.py
@@ -1,3 +1,4 @@
+from .config2 import FieldOptions as FieldOptions
 from .io_mixin import IOMixin as IOMixin
 from .types import EFS as EFS
 from .types import ExtraFieldStrategy as ExtraFieldStrategy

--- a/src/dataclassio/config2.py
+++ b/src/dataclassio/config2.py
@@ -51,7 +51,6 @@ class OptionSpec(tp.Generic[T]):
     type_str: str
     default: T
     scopes: tp.Mapping[Scope, Propagation]
-    to_str: tp.Callable[[T], str]
 
 
 S = Scope
@@ -61,8 +60,11 @@ EXTRA_FIELD_STRATEGY = OptionSpec(
     name="extra_field_strategy",
     type_str="EFS",
     default=EFS.IGNORE,
-    scopes={S.CALL: P.DEEP, S.TYPE: P.LOCAL, S.FIELD: P.DEEP_ONCE},
-    to_str=lambda x: f"efs_{x.value}",
+    scopes={
+        S.CALL: P.DEEP,
+        S.TYPE: P.LOCAL,
+        S.FIELD: P.DEEP_ONCE,
+    },
 )
 
 DISCRIMINATOR = OptionSpec(
@@ -70,10 +72,9 @@ DISCRIMINATOR = OptionSpec(
     type_str="NoValueOr[str]",
     default=NO_VALUE,
     scopes={
+        # Consider adding S.TYPE: P.LOCAL for default discriminators for a type.
         S.FIELD: P.LOCAL,
-        # Conside r adding S.TYPE: P.LOCAL for default discriminators for a type.
     },
-    to_str=lambda x: f"discriminator_{x}",
 )
 
 SKIP_IF_DEFAULT = OptionSpec(
@@ -84,7 +85,6 @@ SKIP_IF_DEFAULT = OptionSpec(
         # S.TYPE: P.PARENT,
         S.FIELD: P.LOCAL,
     },
-    to_str=lambda x: f"skip_if_default_{x}",
 )
 
 SKIP_DEFAULTS = OptionSpec(
@@ -96,7 +96,6 @@ SKIP_DEFAULTS = OptionSpec(
         S.TYPE: P.LOCAL,
         S.FIELD: P.DEEP_ONCE,
     },
-    to_str=lambda x: f"skip_defaults_{x}",
 )
 
 INCLUDE_SRC_IN_DOCSTRING = OptionSpec(
@@ -104,7 +103,6 @@ INCLUDE_SRC_IN_DOCSTRING = OptionSpec(
     type_str="bool",
     default=False,
     scopes={S.CALL: P.DEEP},
-    to_str=lambda _: "incl_src",
 )
 
 SKIP_HOOKS = OptionSpec(
@@ -116,18 +114,34 @@ SKIP_HOOKS = OptionSpec(
         S.TYPE: P.LOCAL,
         S.FIELD: P.DEEP_ONCE,
     },
-    to_str=lambda _: "skip_hooks",
+)
+
+DUMP_OPT = OptionSpec(
+    name="dump",
+    type_str="bool",
+    default=True,
+    scopes={S.FIELD: P.LOCAL},
+)
+
+DUMP_EXTRAS = OptionSpec(
+    name="dump_extras",
+    type_str="bool",
+    default=True,
+    scopes={S.CALL: P.DEEP},
 )
 
 
-ALL_OPTIONS: tuple[OptionSpec, ...] = (
+ALL_OPTIONS: list[OptionSpec] = [
     EXTRA_FIELD_STRATEGY,
     DISCRIMINATOR,
     SKIP_IF_DEFAULT,
     SKIP_DEFAULTS,
     INCLUDE_SRC_IN_DOCSTRING,
     SKIP_HOOKS,
-)
+    DUMP_OPT,
+    DUMP_EXTRAS,
+]
+ALL_OPTIONS.sort(key=lambda os: os.name)
 
 REGISTRY: dict[str, OptionSpec] = {o.name: o for o in ALL_OPTIONS}
 
@@ -139,9 +153,10 @@ REGISTRY: dict[str, OptionSpec] = {o.name: o for o in ALL_OPTIONS}
 
 
 class CallOptions(tp.TypedDict, total=False):
+    dump_extras: bool
     extra_field_strategy: EFS
-    skip_defaults: NoValueOr[bool]
     include_src_in_docstring: bool
+    skip_defaults: NoValueOr[bool]
     skip_hooks: bool
 
 
@@ -152,20 +167,23 @@ class TypeOptions(tp.TypedDict, total=False):
 
 
 class _FieldOptions(tp.TypedDict, total=False):
-    extra_field_strategy: EFS
     discriminator: NoValueOr[str]
-    skip_if_default: NoValueOr[bool]
+    dump: bool
+    extra_field_strategy: EFS
     skip_defaults: NoValueOr[bool]
     skip_hooks: bool
+    skip_if_default: NoValueOr[bool]
 
 
 class DioOptions(tp.TypedDict, total=True):
-    extra_field_strategy: EFS
     discriminator: NoValueOr[str]
-    skip_if_default: NoValueOr[bool]
-    skip_defaults: NoValueOr[bool]
+    dump: bool
+    dump_extras: bool
+    extra_field_strategy: EFS
     include_src_in_docstring: bool
+    skip_defaults: NoValueOr[bool]
     skip_hooks: bool
+    skip_if_default: NoValueOr[bool]
 
 
 def FieldOptions(**kw: tp.Unpack[_FieldOptions]):
@@ -265,12 +283,14 @@ class ResolvedConfig:
 
     def as_dict(self):
         return DioOptions(
-            extra_field_strategy=self["extra_field_strategy"],
             discriminator=self["discriminator"],
-            skip_defaults=self["skip_defaults"],
-            skip_if_default=self["skip_if_default"],
+            dump=self["dump"],
+            dump_extras=self["dump_extras"],
+            extra_field_strategy=self["extra_field_strategy"],
             include_src_in_docstring=self["include_src_in_docstring"],
+            skip_defaults=self["skip_defaults"],
             skip_hooks=self["skip_hooks"],
+            skip_if_default=self["skip_if_default"],
         )
 
     def cache_key(self):

--- a/src/dataclassio/config2.py
+++ b/src/dataclassio/config2.py
@@ -106,7 +106,7 @@ INCLUDE_SRC_IN_DOCSTRING = OptionSpec(
 )
 
 SKIP_HOOKS = OptionSpec(
-    name="skip_hooks",
+    name="disable_hooks",
     type_str="bool",
     default=False,
     scopes={
@@ -116,17 +116,17 @@ SKIP_HOOKS = OptionSpec(
     },
 )
 
-DUMP_OPT = OptionSpec(
-    name="dump",
+SKIP_DUMP = OptionSpec(
+    name="skip",
     type_str="bool",
-    default=True,
+    default=False,
     scopes={S.FIELD: P.LOCAL},
 )
 
-DUMP_EXTRAS = OptionSpec(
-    name="dump_extras",
+SKIP_EXTRAS = OptionSpec(
+    name="skip_extras",
     type_str="bool",
-    default=True,
+    default=False,
     scopes={S.CALL: P.DEEP},
 )
 
@@ -138,8 +138,8 @@ ALL_OPTIONS: list[OptionSpec] = [
     SKIP_DEFAULTS,
     INCLUDE_SRC_IN_DOCSTRING,
     SKIP_HOOKS,
-    DUMP_OPT,
-    DUMP_EXTRAS,
+    SKIP_DUMP,
+    SKIP_EXTRAS,
 ]
 ALL_OPTIONS.sort(key=lambda os: os.name)
 
@@ -153,36 +153,36 @@ REGISTRY: dict[str, OptionSpec] = {o.name: o for o in ALL_OPTIONS}
 
 
 class CallOptions(tp.TypedDict, total=False):
-    dump_extras: bool
+    disable_hooks: bool
     extra_field_strategy: EFS
     include_src_in_docstring: bool
     skip_defaults: NoValueOr[bool]
-    skip_hooks: bool
+    skip_extras: bool
 
 
 class TypeOptions(tp.TypedDict, total=False):
+    disable_hooks: bool
     extra_field_strategy: EFS
     skip_defaults: NoValueOr[bool]
-    skip_hooks: bool
 
 
 class _FieldOptions(tp.TypedDict, total=False):
+    disable_hooks: bool
     discriminator: NoValueOr[str]
-    dump: bool
     extra_field_strategy: EFS
+    skip: bool
     skip_defaults: NoValueOr[bool]
-    skip_hooks: bool
     skip_if_default: NoValueOr[bool]
 
 
 class DioOptions(tp.TypedDict, total=True):
+    disable_hooks: bool
     discriminator: NoValueOr[str]
-    dump: bool
-    dump_extras: bool
     extra_field_strategy: EFS
     include_src_in_docstring: bool
+    skip: bool
     skip_defaults: NoValueOr[bool]
-    skip_hooks: bool
+    skip_extras: bool
     skip_if_default: NoValueOr[bool]
 
 
@@ -284,12 +284,12 @@ class ResolvedConfig:
     def as_dict(self):
         return DioOptions(
             discriminator=self["discriminator"],
-            dump=self["dump"],
-            dump_extras=self["dump_extras"],
+            skip=self["skip"],
+            skip_extras=self["skip_extras"],
             extra_field_strategy=self["extra_field_strategy"],
             include_src_in_docstring=self["include_src_in_docstring"],
             skip_defaults=self["skip_defaults"],
-            skip_hooks=self["skip_hooks"],
+            disable_hooks=self["disable_hooks"],
             skip_if_default=self["skip_if_default"],
         )
 

--- a/src/dataclassio/core/from_dict.py
+++ b/src/dataclassio/core/from_dict.py
@@ -103,7 +103,7 @@ def make_from_dict_source_code(
     # Start with the try/except block for required keys.
     body = TextLines(spacer=_SPACER)
 
-    if overrides_hook(cls, _PRE_FROM_DICT_HOOK) and not frame_config["skip_hooks"]:
+    if overrides_hook(cls, _PRE_FROM_DICT_HOOK) and not frame_config["disable_hooks"]:
         body.append(f"dikt = {cls_factory_name}.{_PRE_FROM_DICT_HOOK}(dikt)")
 
     req_fields = [v for v in field_data.values() if not v.has_default]
@@ -158,7 +158,7 @@ def make_from_dict_source_code(
     # N.B. For EFS.STRICT, this _could_ go at the top of the function body to bail early
     body.extend(extras)
 
-    if overrides_hook(cls, _POST_FROM_DICT_HOOK) and not frame_config["skip_hooks"]:
+    if overrides_hook(cls, _POST_FROM_DICT_HOOK) and not frame_config["disable_hooks"]:
         body.append(f"inst.{_POST_FROM_DICT_HOOK}(dikt)")
 
     body.append("return inst")

--- a/src/dataclassio/core/to_dict.py
+++ b/src/dataclassio/core/to_dict.py
@@ -44,6 +44,11 @@ def make_to_dict_source_code(
         # Form the expression itself that gets the value.
         field_opts = f.metadata.get("dio")
         field_config = frame_config.build_field_config(field_opts)
+        field_config_dict = field_config.as_dict()
+
+        if not field_config_dict["dump"]:
+            continue
+
         child_inherited = field_config.project_for_child()
         cache_key = child_inherited.legacy_cache_key
 
@@ -54,7 +59,7 @@ def make_to_dict_source_code(
                 namespace=_ns,
                 maker_func=partial(make_to_dict, inherited_config=child_inherited, _ns=_ns),
                 cache_key=cache_key,
-                options=field_config.as_dict(),
+                options=field_config_dict,
                 func_prefix="serialize",
             ),
         )
@@ -69,7 +74,7 @@ def make_to_dict_source_code(
         #  field(skip_defaults=...) is meant for the next frame, not this one.
 
         skip_this_field: bool = False
-        if (s := field_config["skip_if_default"]) is not NO_VALUE or (
+        if (s := field_config_dict["skip_if_default"]) is not NO_VALUE or (
             s := frame_config["skip_defaults"]
         ) is not NO_VALUE:
             skip_this_field = s
@@ -87,32 +92,33 @@ def make_to_dict_source_code(
             # Either this field has no default, or we are keeping all values. This easy.
             literal_lines.append(f"{f.name!r}: {field_expr},")
 
-    # Handle the extra fields. If there are no "default checking" lines, we can pack this into
-    #  the bottom of the literals. If we do check some fields for their default value,
-    #  we include the extra field population right before export to try keeping the "real"
-    #  fields in order in the resulting dictionary.
-    if issubclass(cls, IOMixin):
-        # Subclasses of IOMixin _always_ define an _EXTRA_FIELD_ATTR_NAME,
-        #  so we don't need to use the get attr with a string literal.
-        extras_expr = f"inst.{_EXTRA_FIELD_ATTR_NAME!s}"
-        has_extras_attr = True
-    else:
-        # Otherwise, the object may not define the attribute, so use
-        extras_expr = f"getattr(inst, {_EXTRA_FIELD_ATTR_NAME!r}, {{}})"
-        has_extras_attr = False
+    if frame_config["dump_extras"]:
+        # Handle the extra fields. If there are no "default checking" lines, we can pack this into
+        #  the bottom of the literals. If we do check some fields for their default value,
+        #  we include the extra field population right before export to try keeping the "real"
+        #  fields in order in the resulting dictionary.
+        if issubclass(cls, IOMixin):
+            # Subclasses of IOMixin _always_ define an _EXTRA_FIELD_ATTR_NAME,
+            #  so we don't need to use the get attr with a string literal.
+            extras_expr = f"inst.{_EXTRA_FIELD_ATTR_NAME!s}"
+            has_extras_attr = True
+        else:
+            # Otherwise, the object may not define the attribute, so use
+            extras_expr = f"getattr(inst, {_EXTRA_FIELD_ATTR_NAME!r}, {{}})"
+            has_extras_attr = False
 
-    if not default_check_lines:
-        # If there are no default value checks, we can bake this directly into the dict literal
-        literal_lines.append(f"**{extras_expr},")
-    elif has_extras_attr:
-        # Need to call `dikt.update`. We have an extras_attr.
-        default_check_lines.append(f"dikt.update({extras_expr})")
-    else:
-        # Need to call `dikt.update`. We may or may not have an extras_attr.
-        #  It is faster to use getattr(..., None)
-        default_check_lines.append(f"_extras = {extras_expr.format('None')}")
-        with default_check_lines.indent("if _extras is not None:"):
-            default_check_lines.append("dikt.update(_extras)")
+        if not default_check_lines:
+            # If there are no default value checks, we can bake this directly into the dict literal
+            literal_lines.append(f"**{extras_expr},")
+        elif has_extras_attr:
+            # Need to call `dikt.update`. We have an extras_attr.
+            default_check_lines.append(f"dikt.update({extras_expr})")
+        else:
+            # Need to call `dikt.update`. We may or may not have an extras_attr.
+            #  It is faster to use getattr(..., None)
+            default_check_lines.append(f"_extras = {extras_expr.format('None')}")
+            with default_check_lines.indent("if _extras is not None:"):
+                default_check_lines.append("dikt.update(_extras)")
 
     lines = TextLines(spacer=_SPACER)
     funcname = frame_config.get_func_name(cls, "serialize")

--- a/src/dataclassio/core/to_dict.py
+++ b/src/dataclassio/core/to_dict.py
@@ -46,7 +46,7 @@ def make_to_dict_source_code(
         field_config = frame_config.build_field_config(field_opts)
         field_config_dict = field_config.as_dict()
 
-        if not field_config_dict["dump"]:
+        if field_config_dict["skip"]:
             continue
 
         child_inherited = field_config.project_for_child()
@@ -92,7 +92,7 @@ def make_to_dict_source_code(
             # Either this field has no default, or we are keeping all values. This easy.
             literal_lines.append(f"{f.name!r}: {field_expr},")
 
-    if frame_config["dump_extras"]:
+    if not frame_config["skip_extras"]:
         # Handle the extra fields. If there are no "default checking" lines, we can pack this into
         #  the bottom of the literals. If we do check some fields for their default value,
         #  we include the extra field population right before export to try keeping the "real"
@@ -123,7 +123,7 @@ def make_to_dict_source_code(
     lines = TextLines(spacer=_SPACER)
     funcname = frame_config.get_func_name(cls, "serialize")
 
-    if frame_config["skip_hooks"]:
+    if frame_config["disable_hooks"]:
         insert_pre = False
         insert_post = False
     else:

--- a/src/dataclassio/io_mixin.py
+++ b/src/dataclassio/io_mixin.py
@@ -1,6 +1,7 @@
 import contextlib
 import io
 import json
+import types
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -31,10 +32,9 @@ class IOMixin:
 
     @property
     def extra_fields(self):
-        """Shallow copy of the extra fields stored in this instance from deserialization."""
-        if hasattr(self, _EXTRA_FIELD_ATTR_NAME):
-            return dict(getattr(self, _EXTRA_FIELD_ATTR_NAME))
-        return {}
+        """Readonly view of the extra fields stored in this instance from deserialization."""
+        d = getattr(self, _EXTRA_FIELD_ATTR_NAME, {})
+        return types.MappingProxyType(d)
 
     # IO methods
 

--- a/tests/test_dump_option.py
+++ b/tests/test_dump_option.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass, field
+
+from dataclassio import functional as F
+from dataclassio.config2 import FieldOptions
+
+
+class TestDump:
+    def test_dump_true_by_default(self):
+        @dataclass
+        class MyClass:
+            x: int
+            y: int
+
+        obj = MyClass(x=1, y=2)
+        assert F.to_dict(obj) == {"x": 1, "y": 2}
+
+    def test_dump_false_excludes_field(self):
+        @dataclass
+        class MyClass:
+            x: int
+            y: int = field(metadata=FieldOptions(dump=False))
+
+        obj = MyClass(x=1, y=2)
+        assert F.to_dict(obj) == {"x": 1}
+
+    def test_dump_false_on_all_fields(self):
+        """Test that all fields can be disabled without issue."""
+
+        @dataclass
+        class MyClass:
+            x: int = field(metadata=FieldOptions(dump=False))
+            y: int = field(metadata=FieldOptions(dump=False))
+            z: str = field(metadata=FieldOptions(dump=False))
+
+        obj = MyClass(x=1, y=2, z="hello")
+        assert F.to_dict(obj) == {}

--- a/tests/test_dump_option.py
+++ b/tests/test_dump_option.py
@@ -18,7 +18,7 @@ class TestDump:
         @dataclass
         class MyClass:
             x: int
-            y: int = field(metadata=FieldOptions(dump=False))
+            y: int = field(metadata=FieldOptions(skip=True))
 
         obj = MyClass(x=1, y=2)
         assert F.to_dict(obj) == {"x": 1}
@@ -28,9 +28,9 @@ class TestDump:
 
         @dataclass
         class MyClass:
-            x: int = field(metadata=FieldOptions(dump=False))
-            y: int = field(metadata=FieldOptions(dump=False))
-            z: str = field(metadata=FieldOptions(dump=False))
+            x: int = field(metadata=FieldOptions(skip=True))
+            y: int = field(metadata=FieldOptions(skip=True))
+            z: str = field(metadata=FieldOptions(skip=True))
 
         obj = MyClass(x=1, y=2, z="hello")
         assert F.to_dict(obj) == {}

--- a/tests/test_extra_fields.py
+++ b/tests/test_extra_fields.py
@@ -12,6 +12,10 @@ class TestDictExtras:
         inst = kls.from_dict(dikt, extra_field_strategy=EFS.IGNORE)
         assert not inst.extra_fields, "expected extra_fields to be empty"
 
+        # And skipping extras works as expected
+        dikt.pop("bonus")
+        assert inst.to_dict(dump_extras=False) == dikt
+
     def test_strict(self):
         kls = _sch.CocoCategory
         dikt = {"id": 1, "name": "person", "supercategory": "person", "bonus": "bonus"}
@@ -19,10 +23,28 @@ class TestDictExtras:
         with pytest.raises(ValueError, match="extra fields.*bonus"):
             kls.from_dict(dikt, extra_field_strategy=EFS.STRICT)
 
+        # Removing the extra field fixes the issue.
+        dikt.pop("bonus")
+        inst = kls.from_dict(dikt)
+
+        # And dumping w/o the extras has no issue, of course.
+        assert inst == _sch.CocoCategory(1, "person", "person")
+        assert inst.to_dict(dump_extras=False) == dikt
+
     def test_capture(self):
         kls = _sch.CocoCategory
         dikt = {"id": 1, "name": "person", "supercategory": "person", "bonus": "bonus"}
 
         inst = kls.from_dict(dikt, extra_field_strategy=EFS.CAPTURE)
         assert inst.extra_fields == {"bonus": "bonus"}
+        assert inst.to_dict() == dikt
+
+        # Check that we can disable dumping extras
+        assert inst.to_dict(dump_extras=False) == {
+            "id": 1,
+            "name": "person",
+            "supercategory": "person",
+        }
+
+        # And toggle it back on with the next call
         assert inst.to_dict() == dikt

--- a/tests/test_extra_fields.py
+++ b/tests/test_extra_fields.py
@@ -14,7 +14,7 @@ class TestDictExtras:
 
         # And skipping extras works as expected
         dikt.pop("bonus")
-        assert inst.to_dict(dump_extras=False) == dikt
+        assert inst.to_dict(skip_extras=True) == dikt
 
     def test_strict(self):
         kls = _sch.CocoCategory
@@ -29,7 +29,7 @@ class TestDictExtras:
 
         # And dumping w/o the extras has no issue, of course.
         assert inst == _sch.CocoCategory(1, "person", "person")
-        assert inst.to_dict(dump_extras=False) == dikt
+        assert inst.to_dict(skip_extras=True) == dikt
 
     def test_capture(self):
         kls = _sch.CocoCategory
@@ -40,7 +40,7 @@ class TestDictExtras:
         assert inst.to_dict() == dikt
 
         # Check that we can disable dumping extras
-        assert inst.to_dict(dump_extras=False) == {
+        assert inst.to_dict(skip_extras=True) == {
             "id": 1,
             "name": "person",
             "supercategory": "person",

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -286,7 +286,7 @@ class TestCallLevelSkipHooks:
 
     def test_to_dict_skips_hooks_when_requested(self):
         h = Hooked(1, 2)
-        d = h.to_dict(skip_hooks=True)
+        d = h.to_dict(disable_hooks=True)
         assert h.calls == []
         assert "post_to_dict" not in d
 
@@ -298,7 +298,7 @@ class TestCallLevelSkipHooks:
         # __pre_from_dict__ would inject a default for x; skipping should
         # mean the missing key causes the usual error path.
         with pytest.raises(KeyError):
-            Hooked.from_dict({"y": 2}, skip_hooks=True)
+            Hooked.from_dict({"y": 2}, disable_hooks=True)
 
-        h = Hooked.from_dict({"x": 1, "y": 2}, skip_hooks=True)
+        h = Hooked.from_dict({"x": 1, "y": 2}, disable_hooks=True)
         assert h.calls == []


### PR DESCRIPTION
See title, pretty self-explanatory. The one thing we may want to consider adding to this is another call-/type-, option to skip `init=False` fields during dump. This does complicate the config schema, though, but not majorly. We'd need to make the default value for `skip=NO_VALUE` since we'd need to differentiate between "unspecified" and "explicitly do not skip" for cases where the user wants to skip `init=False` fields by default.